### PR TITLE
ci: Fix the "chore" workflow for pull requests from forks

### DIFF
--- a/.github/workflows/chore.yml
+++ b/.github/workflows/chore.yml
@@ -1,6 +1,6 @@
 name: Chore
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, reopened, edited, synchronize]
   push:
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   check-pr-title:
     name: Check PR Title
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -51,16 +51,16 @@ jobs:
           delete: true
 
   release-drafter:
-    name: ${{ github.event_name == 'pull_request' && 'Assign Labels' || 'Draft Release' }}
+    name: ${{ github.event_name == 'pull_request_target' && 'Assign Labels' || 'Draft Release' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: ${{ github.event_name == 'pull_request' && 'Assign labels' || 'Update release draft' }}
+      - name: ${{ github.event_name == 'pull_request_target' && 'Assign labels' || 'Update release draft' }}
         uses: release-drafter/release-drafter@v6
         with:
-          disable-releaser: ${{ github.event_name == 'pull_request' }}
+          disable-releaser: ${{ github.event_name == 'pull_request_target' }}
           disable-autolabeler: ${{ github.event_name == 'push' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Motivation

PRs like #1 are not properly assigned labels as the token associated with PRs from pull requests does not have sufficient permissions to label PRs (or leave PR comments).

# Changes

- Change the trigger from `pull_request` to `pull_request_target` to execute the workflow with elevated permissions
