### PR TITLE
ci: Add token for uploading code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Motivation

codecov apparently requires an upload token even for public repos (kinda makes sense, I guess).
