### PR TITLE
fix: Allow to make annotated collection members optional

### DIFF
--- a/tests/collection/test_implementation.py
+++ b/tests/collection/test_implementation.py
@@ -81,6 +81,24 @@ def test_annotation_union_conflicting_types_failure() -> None:
         )
 
 
+def test_annotation_annotated_success() -> None:
+    """When we use an Annotated type, it must accept a union type."""
+    create_collection_raw(
+        "test",
+        {
+            "first": Annotated[
+                dy.LazyFrame[MyTestSchema] | None, dy.CollectionMember()
+            ],
+        },
+    )
+    create_collection_raw(
+        "test",
+        {
+            "first": dy.LazyFrame[MyTestSchema] | None,
+        },
+    )
+
+
 def test_annotation_only_none_failure() -> None:
     """Annotations must not just be None."""
     with pytest.raises(AnnotationImplementationError):


### PR DESCRIPTION
# Motivation

This PR fixes two issues in one:

- Annotating optional collection members currently fails with the following issue:
  ```
  TypeError: issubclass() arg 1 must be a class
  ```
- Even if that did not fail, inlining optional collection members for sampling would fail due to a missing flag

