### PR TITLE
feat: Add `dy.Object` column type

### DIFF
--- a/dataframely/__init__.py
+++ b/dataframely/__init__.py
@@ -34,6 +34,7 @@ from .columns import (
     Int64,
     Integer,
     List,
+    Object,
     String,
     Struct,
     Time,
@@ -89,4 +90,5 @@ __all__ = [
     "String",
     "Struct",
     "List",
+    "Object",
 ]

--- a/dataframely/columns/__init__.py
+++ b/dataframely/columns/__init__.py
@@ -10,6 +10,7 @@ from .enum import Enum
 from .float import Float, Float32, Float64
 from .integer import Int8, Int16, Int32, Int64, Integer, UInt8, UInt16, UInt32, UInt64
 from .list import List
+from .object import Object
 from .string import String
 from .struct import Struct
 
@@ -31,6 +32,7 @@ __all__ = [
     "Int32",
     "Int64",
     "Integer",
+    "Object",
     "UInt8",
     "UInt16",
     "UInt32",

--- a/dataframely/columns/object.py
+++ b/dataframely/columns/object.py
@@ -59,4 +59,6 @@ class Object(Column):
         raise NotImplementedError("PyArrow column cannot have 'Object' type.")
 
     def _sample_unchecked(self, generator: Generator, n: int) -> pl.Series:
-        return pl.Series([object() for _ in range(n)])
+        raise NotImplementedError(
+            "Random data sampling not implemented for 'Object' type."
+        )

--- a/dataframely/columns/object.py
+++ b/dataframely/columns/object.py
@@ -1,0 +1,62 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import polars as pl
+
+from dataframely._compat import pa, sa, sa_TypeEngine
+from dataframely.random import Generator
+
+from ._base import Column
+
+
+class Object(Column):
+    """A Python Object column."""
+
+    def __init__(
+        self,
+        *,
+        nullable: bool = True,
+        primary_key: bool = False,
+        check: Callable[[pl.Expr], pl.Expr] | None = None,
+        alias: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        """
+        Args:
+            nullable: Whether this column may contain null values.
+            primary_key: Whether this column is part of the primary key of the schema.
+            check: A custom check to run for this column. Must return a non-aggregated
+                boolean expression.
+            alias: An overwrite for this column's name which allows for using a column
+                name that is not a valid Python identifier. Especially note that setting
+                this option does _not_ allow to refer to the column with two different
+                names, the specified alias is the only valid name.
+            metadata: A dictionary of metadata to attach to the column.
+        """
+        super().__init__(
+            nullable=nullable,
+            primary_key=primary_key,
+            check=check,
+            alias=alias,
+            metadata=metadata,
+        )
+
+    @property
+    def dtype(self) -> pl.DataType:
+        return pl.Object()
+
+    def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
+        # NOTE: We might want to add support for PostgreSQL's JSON in the future.
+        raise NotImplementedError("SQL column cannot have 'Object' type.")
+
+    @property
+    def pyarrow_dtype(self) -> pa.DataType:
+        raise NotImplementedError("PyArrow column cannot have 'Object' type.")
+
+    def _sample_unchecked(self, generator: Generator, n: int) -> pl.Series:
+        return pl.Series([object() for _ in range(n)])

--- a/dataframely/columns/object.py
+++ b/dataframely/columns/object.py
@@ -51,7 +51,6 @@ class Object(Column):
         return pl.Object()
 
     def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
-        # NOTE: We might want to add support for PostgreSQL's JSON in the future.
         raise NotImplementedError("SQL column cannot have 'Object' type.")
 
     @property

--- a/tests/column_types/test_object.py
+++ b/tests/column_types/test_object.py
@@ -45,11 +45,16 @@ def test_validate_dtype(column: Column, dtype: pl.DataType, is_valid: bool) -> N
 
 def test_pyarrow_dtype_raises() -> None:
     column = dy.Object()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError, match="PyArrow column cannot have 'Object' type."
+    ):
         column.pyarrow_dtype
 
 
 def test_sampling_raises() -> None:
     column = dy.Object()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(
+        NotImplementedError,
+        match="Random data sampling not implemented for 'Object' type.",
+    ):
         column.sample(generator=Generator(), n=10)

--- a/tests/column_types/test_object.py
+++ b/tests/column_types/test_object.py
@@ -43,16 +43,10 @@ def test_validate_dtype(column: Column, dtype: pl.DataType, is_valid: bool) -> N
     assert column.validate_dtype(dtype) == is_valid
 
 
-def test_sqlalchemy_dtype_raises() -> None:
-    column = dy.Object()
-    with pytest.raises(NotImplementedError):
-        column.sqlalchemy_dtype(None)  # type: ignore[arg-type]
-
-
 def test_pyarrow_dtype_raises() -> None:
     column = dy.Object()
     with pytest.raises(NotImplementedError):
-        column.pyarrow_dtype()
+        column.pyarrow_dtype
 
 
 def test_sampling_raises() -> None:

--- a/tests/column_types/test_object.py
+++ b/tests/column_types/test_object.py
@@ -7,6 +7,7 @@ import pytest
 
 import dataframely as dy
 from dataframely.columns._base import Column
+from dataframely.random import Generator
 from dataframely.testing import create_schema
 
 
@@ -40,3 +41,21 @@ def test_simple_object() -> None:
 )
 def test_validate_dtype(column: Column, dtype: pl.DataType, is_valid: bool) -> None:
     assert column.validate_dtype(dtype) == is_valid
+
+
+def test_sqlalchemy_dtype_raises() -> None:
+    column = dy.Object()
+    with pytest.raises(NotImplementedError):
+        column.sqlalchemy_dtype(None)  # type: ignore[arg-type]
+
+
+def test_pyarrow_dtype_raises() -> None:
+    column = dy.Object()
+    with pytest.raises(NotImplementedError):
+        column.pyarrow_dtype()
+
+
+def test_sampling_raises() -> None:
+    column = dy.Object()
+    with pytest.raises(NotImplementedError):
+        column.sample(generator=Generator(), n=10)

--- a/tests/column_types/test_object.py
+++ b/tests/column_types/test_object.py
@@ -1,0 +1,42 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+import polars as pl
+import pytest
+
+import dataframely as dy
+from dataframely.columns._base import Column
+from dataframely.testing import create_schema
+
+
+class CustomObject:
+    def __init__(self, a: int, b: str) -> None:
+        self.a = a
+        self.b = b
+
+
+def test_simple_object() -> None:
+    schema = create_schema("test", {"o": dy.Object()})
+    assert schema.is_valid(
+        pl.DataFrame({"o": [CustomObject(a=1, b="foo"), CustomObject(a=2, b="bar")]})
+    )
+
+
+@pytest.mark.parametrize(
+    ("column", "dtype", "is_valid"),
+    [
+        (
+            dy.Object(),
+            pl.Object(),
+            True,
+        ),
+        (
+            dy.Object(),
+            object(),
+            False,
+        ),
+    ],
+)
+def test_validate_dtype(column: Column, dtype: pl.DataType, is_valid: bool) -> None:
+    assert column.validate_dtype(dtype) == is_valid

--- a/tests/columns/test_sql_schema.py
+++ b/tests/columns/test_sql_schema.py
@@ -145,3 +145,11 @@ def test_raise_for_struct_column(dialect: sa.Dialect) -> None:
         NotImplementedError, match="SQL column cannot have 'Struct' type."
     ):
         dy.Struct({"a": dy.String()}).sqlalchemy_dtype(dialect)
+
+
+@pytest.mark.parametrize("dialect", [MSDialect_pyodbc(), PGDialect_psycopg2()])
+def test_raise_for_object_column(dialect: sa.Dialect) -> None:
+    with pytest.raises(
+        NotImplementedError, match="SQL column cannot have 'Object' type."
+    ):
+        dy.Object().sqlalchemy_dtype(dialect)


### PR DESCRIPTION
# Motivation

Closes #11.

# Changes

Add `dy.Object` column type as requested by the community.
For now, we don't implement sampling which is not straightforward for arbitrary python objects.
