### PR TITLE
fix: Make group rules work on nullable grouping columns

### DIFF
--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -126,5 +126,7 @@ def _with_group_rules(lf: pl.LazyFrame, rules: dict[str, GroupRule]) -> pl.LazyF
     #    preserves the order of the left data frame.
     result = lf
     for group_columns, frame in group_evaluations.items():
-        result = result.join(frame, on=list(group_columns), how="left", nulls_equal=True)
+        result = result.join(
+            frame, on=list(group_columns), how="left", nulls_equal=True
+        )
     return result

--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -126,5 +126,5 @@ def _with_group_rules(lf: pl.LazyFrame, rules: dict[str, GroupRule]) -> pl.LazyF
     #    preserves the order of the left data frame.
     result = lf
     for group_columns, frame in group_evaluations.items():
-        result = result.join(frame, on=list(group_columns), how="left")
+        result = result.join(frame, on=list(group_columns), how="left", nulls_equal=True)
     return result

--- a/tests/schema/test_validate.py
+++ b/tests/schema/test_validate.py
@@ -117,12 +117,11 @@ def test_success_multi_row_strip_cast(
     assert_frame_equal(actual, expected)
     assert MySchema.is_valid(df, cast=True)
 
+
 @pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
-def test_group_rule_on_nulls(
-    df_type: type[pl.DataFrame] | type[pl.LazyFrame]
-):
+def test_group_rule_on_nulls(df_type: type[pl.DataFrame] | type[pl.LazyFrame]) -> None:
     # The schema is violated because we have multiple "b" values for the same "a" value
-    df = df_type({"a" : [None, None],"b" : [1, 2]})
+    df = df_type({"a": [None, None], "b": [1, 2]})
     with pytest.raises(RuleValidationError):
         MyComplexSchema.validate(df, cast=True)
     assert not MyComplexSchema.is_valid(df, cast=True)

--- a/tests/schema/test_validate.py
+++ b/tests/schema/test_validate.py
@@ -116,3 +116,13 @@ def test_success_multi_row_strip_cast(
     )
     assert_frame_equal(actual, expected)
     assert MySchema.is_valid(df, cast=True)
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+def test_group_rule_on_nulls(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame]
+):
+    # The schema is violated because we have multiple "b" values for the same "a" value
+    df = df_type({"a" : [None, None],"b" : [1, 2]})
+    with pytest.raises(RuleValidationError):
+        MyComplexSchema.validate(df, cast=True)
+    assert not MyComplexSchema.is_valid(df, cast=True)


### PR DESCRIPTION
# Motivation

Fixes #15 

# Changes

* Added `nulls_equal=True` to polars join used to accumulate group rule evaluation results.