### PR TITLE
fix: Make enums tolerate multiple sequence types

### DIFF
--- a/dataframely/columns/enum.py
+++ b/dataframely/columns/enum.py
@@ -49,7 +49,7 @@ class Enum(Column):
             alias=alias,
             metadata=metadata,
         )
-        self.categories = categories
+        self.categories = list(categories)
 
     @property
     def dtype(self) -> pl.DataType:

--- a/tests/column_types/test_enum.py
+++ b/tests/column_types/test_enum.py
@@ -52,3 +52,12 @@ def test_valid_cast(
     schema = create_schema("test", {"a": enum})
     df = df_type(data)
     assert schema.is_valid(df, cast=True) == valid
+
+
+@pytest.mark.parametrize("type1", [list, tuple])
+@pytest.mark.parametrize("type2", [list, tuple])
+def test_different_sequences(type1: type, type2: type) -> None:
+    allowed = ["a", "b"]
+    S = create_schema("test", {"x": dy.Enum(type1(allowed))})
+    df = pl.DataFrame({"x": pl.Series(["a", "b"], dtype=pl.Enum(type2(allowed)))})
+    S.validate(df)


### PR DESCRIPTION
# Motivation

Fixes #17, which actually has nothing to do with parquet. The parquet connection just happened because the enum categories are always a `list` after going through parquet.

# Changes

* Added `list` cast to ensure that `Enum.categories` is always stored as a list internally.
* Added a test that fails without the fix. @delsner @borchero : I wasn't 100% sure what file the test should be in. Let me know if you think it should go somewhere else.