### PR TITLE
fix: Generate nulls for Nullable list/struct in `sample`

### DIFF
--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -147,4 +147,7 @@ class List(Column):
                 chain([0], element_lengths.cum_sum()), element_lengths
             )
         ]
-        return pl.Series(list_elements)
+        # Finally, apply a null mask
+        return generator._apply_null_mask(
+            pl.Series(list_elements), null_probability=self._null_probability
+        )

--- a/dataframely/columns/struct.py
+++ b/dataframely/columns/struct.py
@@ -96,10 +96,14 @@ class Struct(Column):
         return pa.struct({name: col.pyarrow_dtype for name, col in self.inner.items()})
 
     def _sample_unchecked(self, generator: Generator, n: int) -> pl.Series:
-        return (
+        series = (
             pl.DataFrame(
                 {name: col.sample(generator, n) for name, col in self.inner.items()}
             )
             .select(pl.struct(pl.all()))
             .to_series()
+        )
+        # Apply a null mask.
+        return generator._apply_null_mask(
+            series, null_probability=self._null_probability
         )

--- a/dataframely/random.py
+++ b/dataframely/random.py
@@ -392,8 +392,10 @@ class Generator:
     def _apply_null_mask(self, series: pl.Series, null_probability: float) -> pl.Series:
         if null_probability == 0:
             return series
-        null_mask = self.numpy_generator.random(series.len()) < null_probability
-        return series.scatter(np.where(null_mask)[0], None)
+        null_mask = (
+            pl.Series(self.numpy_generator.random(series.len())) > null_probability
+        )
+        return pl.select(pl.when(null_mask).then(series)).to_series()
 
 
 # --------------------------------------- UTILS -------------------------------------- #

--- a/tests/columns/test_sample.py
+++ b/tests/columns/test_sample.py
@@ -184,6 +184,7 @@ def test_sample_list(generator: Generator) -> None:
 def test_sample_struct(generator: Generator) -> None:
     column = dy.Struct({"a": dy.String(regex="[abc]"), "b": dy.String(regex="[a-z]xx")})
     samples = sample_and_validate(column, generator, n=10_000)
+    assert samples.is_null().any()
     assert len(samples) == 10_000
 
 

--- a/tests/columns/test_sample.py
+++ b/tests/columns/test_sample.py
@@ -178,7 +178,7 @@ def test_sample_enum(generator: Generator) -> None:
 def test_sample_list(generator: Generator) -> None:
     column = dy.List(dy.String(regex="[abc]"), min_length=5, max_length=10)
     samples = sample_and_validate(column, generator, n=10_000)
-    assert set(samples.list.len()) == set(range(5, 11))
+    assert set(samples.list.len()) == set(range(5, 11)) | {None}
 
 
 def test_sample_struct(generator: Generator) -> None:


### PR DESCRIPTION
# Motivation

`sample` should reflects the nullable property of listcolumns.

# Changes

Add `_apply_null_mask` in ``List._sample_unchecked`.

series.scatter is not possible on a list series
```py
pl.Series(dtype=pl.List(pl.Int64)).scatter([0], None) 
# ComputeError: not yet implemented for dtype: list[i64]
```
So I used a pl.when().then() approach which ends up being much faster!


```py

import numpy as np
import polars as pl
s = pl.Series(range(10_000_000))
null_probability = 0.1

numpy_generator = np.random.default_rng()
random_values = numpy_generator.random(s.len())


%%timeit
null_mask = random_values < null_probability
s.scatter(np.where(null_mask)[0], None)
# 35.2 ms ± 3.66 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%%timeit
null_mask = pl.Series(random_values) > null_probability
pl.select(pl.when(null_mask).then(s)).to_series()
# 6.04 ms ± 190 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)

```
EDIT: add the same feature for struct