### PR TITLE
fix: Add `dy.Object` to mypy plugin

### DIFF
--- a/dataframely/mypy.py
+++ b/dataframely/mypy.py
@@ -189,7 +189,7 @@ def _convert_dy_column_to_dtype(
                 ],
             )
         return api.named_type("builtins.list")
-    if column_type == "Any":
+    if column_type == "Any" or column_type == "Object":
         return AnyType(TypeOfAny.explicit)
     # If we can't infer the type, we default to `Any`.
     # This is, for example, the case for self-defined types, e.g., via `functools.partial`.

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -111,6 +111,7 @@ class MySchema(dy.Schema):
     f = dy.Datetime()
     g = dy.Date()
     h = dy.Any()
+    o = dy.Object()
     some_decimal = dy.Decimal(12, 8)
     custom_col = Flags()
     custom_col_list = dy.List(Flags())
@@ -133,6 +134,7 @@ def my_schema_df() -> dy.DataFrame[MySchema]:
                 "f": [datetime.datetime(2022, 1, 1, 0, 0, 0)],
                 "g": [datetime.date(2022, 1, 1)],
                 "h": [1],
+                "o": [object()],
                 "some_decimal": [decimal.Decimal("1.5")],
                 "custom_col": [[{"x": "a", "y": "b"}]],
             }
@@ -209,6 +211,7 @@ def test_iter_rows_imported_schema() -> None:
                 "f": [datetime.datetime(2022, 1, 1, 0, 0, 0)],
                 "g": [datetime.date(2022, 1, 1)],
                 "h": [1],
+                "o": [object()],
                 "some_decimal": [decimal.Decimal("1.5")],
             }
         ),


### PR DESCRIPTION
# Motivation

We forgot to add `dy.Object` to the mypy plugin in #11.

# Changes

Add `dy.Object` to mypy plugin.
