### PR TITLE
fix: Allow `pipe` to be used on typed data frames

### DIFF
--- a/dataframely/_typing.py
+++ b/dataframely/_typing.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate, Generic, ParamSpec, TypeVar
 
 import polars as pl
 
@@ -46,6 +46,14 @@ class DataFrame(pl.DataFrame, Generic[S]):
 
     @inherit_signature(pl.DataFrame.lazy)
     def lazy(self, *args: Any, **kwargs: Any) -> LazyFrame[S]:
+        raise NotImplementedError  # pragma: no cover
+
+    def pipe(
+        self,
+        function: Callable[Concatenate[DataFrame[S], P], R],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R:
         raise NotImplementedError  # pragma: no cover
 
     @inherit_signature(pl.DataFrame.rechunk)
@@ -90,6 +98,14 @@ class LazyFrame(pl.LazyFrame, Generic[S]):
 
     @inherit_signature(pl.LazyFrame.lazy)
     def lazy(self, *args: Any, **kwargs: Any) -> LazyFrame[S]:
+        raise NotImplementedError  # pragma: no cover
+
+    def pipe(
+        self,
+        function: Callable[Concatenate[LazyFrame[S], P], R],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> R:
         raise NotImplementedError  # pragma: no cover
 
     @inherit_signature(pl.LazyFrame.set_sorted)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -32,6 +32,17 @@ class Schema(dy.Schema):
     a = dy.Int64()
 
 
+def pipe_df(df: dy.DataFrame[Schema]) -> pl.DataFrame:
+    return df
+
+
+def pipe_lf(df: dy.LazyFrame[Schema]) -> pl.LazyFrame:
+    return df
+
+
+# ------------------------------------------------------------------------------------ #
+
+
 def test_data_frame_lazy() -> None:
     df = Schema.create_empty()
     df.lazy()
@@ -45,6 +56,14 @@ def test_lazy_frame_lazy() -> None:
 def test_lazy_frame_collect() -> None:
     df = Schema.create_empty(lazy=True)
     df.collect()
+
+
+def test_pipe_df() -> None:
+    Schema.create_empty().pipe(pipe_df)
+
+
+def test_pipe_lf() -> None:
+    Schema.create_empty(lazy=True).pipe(pipe_lf)
 
 
 # ------------------------------------------------------------------------------------ #


### PR DESCRIPTION
# Motivation

Prior to this PR, one cannot use `pipe` with a function expecting a typed data frame, even if the source is a typed data frame. `mypy` complained with the following error:

```
error: Argument 1 to "pipe" of "LazyFrame" has incompatible type "Callable[[dataframely._typing.LazyFrame[Schema]], polars.lazyframe.frame.LazyFrame]"; expected "Callable[[polars.lazyframe.frame.LazyFrame], polars.lazyframe.frame.LazyFrame]"  [arg-type]
```
