### PR TITLE
refactor: Emit FutureWarning on nullable primary key

### DIFF
--- a/dataframely/_deprecation.py
+++ b/dataframely/_deprecation.py
@@ -37,3 +37,14 @@ def warn_nullable_default_change() -> None:
         FutureWarning,
         stacklevel=4,
     )
+
+
+@skip_if(env="DATAFRAMELY_NO_FUTURE_WARNINGS")
+def warn_no_nullable_primary_keys() -> None:
+    warnings.warn(
+        "Nullable primary keys are not supported. "
+        "Setting `nullable=True` on a primary key column is ignored "
+        "and will raise an error in a future release.",
+        FutureWarning,
+        stacklevel=4,
+    )

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -11,7 +11,10 @@ from typing import Any
 import polars as pl
 
 from dataframely._compat import pa, sa, sa_TypeEngine
-from dataframely._deprecation import warn_nullable_default_change
+from dataframely._deprecation import (
+    warn_no_nullable_primary_keys,
+    warn_nullable_default_change,
+)
 from dataframely._polars import PolarsDataType
 from dataframely.random import Generator
 
@@ -67,6 +70,10 @@ class Column(ABC):
                 internally sets the alias to the column's name in the parent schema.
             metadata: A dictionary of metadata to attach to the column.
         """
+
+        if nullable and primary_key:
+            warn_no_nullable_primary_keys()
+
         if nullable is None:
             warn_nullable_default_change()
             nullable = True

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -2,27 +2,62 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import warnings
+from collections.abc import Callable
 
 import pytest
 
 import dataframely as dy
 
+# --------------------- Nullability default change ------------------------------#
 
-def test_column_constructor_warns_about_nullable(
+
+def deprecated_default_nullable() -> None:
+    """This function causes a FutureWarning because no value is specified for the
+    `nullable` argument to the Column constructor."""
+    dy.Integer()
+
+
+def test_warning_deprecated_default_nullable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("DATAFRAMELY_NO_FUTURE_WARNINGS", "")
     with pytest.warns(
         FutureWarning, match="The 'nullable' argument was not explicitly set"
     ):
-        dy.Integer()
+        deprecated_default_nullable()
 
 
+# ------------------------- Nullable primary key  ---------------------------------#
+
+
+def deprecated_nullable_primary_key() -> None:
+    """This function causes a FutureWarning because both `nullable` and `primary_key`
+    are set to `True` in the Column constructor."""
+    dy.Integer(primary_key=True, nullable=True)
+
+
+def test_warning_deprecated_nullable_primary_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATAFRAMELY_NO_FUTURE_WARNINGS", "")
+    with pytest.warns(FutureWarning, match="Nullable primary keys are not supported"):
+        deprecated_nullable_primary_key()
+
+
+# ------------------------- Common  ---------------------------------#
+
+
+@pytest.mark.parametrize(
+    "deprecated_behavior",
+    [deprecated_default_nullable, deprecated_nullable_primary_key],
+)
 @pytest.mark.parametrize("env_var", ["1", "True", "true"])
-def test_future_warning_skip(monkeypatch: pytest.MonkeyPatch, env_var: str) -> None:
+def test_future_warning_skip(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, deprecated_behavior: Callable
+) -> None:
+    """FutureWarnings should be avoidable by setting an environment variable."""
     monkeypatch.setenv("DATAFRAMELY_NO_FUTURE_WARNINGS", env_var)
-
     # Elevates FutureWarning to an exception
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
-        dy.Integer()
+        deprecated_behavior()


### PR DESCRIPTION
# Motivation

Closes #13 

# Changes

* Added a `FutureWarning` when a user sets `nullable` and `primary_key` at the same time. Since `nullable` is otherwise quietly ignored, this should raise an error in a future release.
* refactored warning tests to make it easier to test multiple warnings

<!-- What changes have been performed? -->
