### PR TITLE
refactor: Remove generic parameter from collection

### DIFF
--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -94,7 +94,7 @@ class SamplingType(TypedDict):
     second: NotRequired[SamplingTypeSecond]
 
 
-class MyCollection(dy.Collection[SamplingType]):
+class MyCollection(dy.Collection):
     first: dy.LazyFrame[MyFirstSchema]
     second: dy.LazyFrame[MySecondSchema]
 


### PR DESCRIPTION
# Motivation

`dy.Collection` currently allows specifying a generic parameter. The only purpose of this parameter is to provide a more concrete mapping type for the `sample` method in order to improve type annotations.

For one, this feels odd as the generic parameter influences a minor feature of the collection. It also clashes with the general programmer's notion that a collection's generic parameter influences the type of objects found in the collection.

In addition, however, this generic parameter also poses a serious problem when inheriting collections and wanting to sample both the parent and the child collection (as @MoritzPotthoffQC ran into).

For both of these reasons, I propose to get rid of the generic parameter.

# Changes

- Remove the generic parameter from `dy.Collection`, falling back to users providing simple mappings for sampling
- Copy the user input for the overrides to prevent in-place modifications in `_preprocess_sample`. This is largely orthogonal to the core change in this PR but required to turn the `Mapping` input into a `MutableMapping` (or the more concrete type `dict`)

---

Main question: Do we think this change warrants a major release? I'd expect this feature to mostly be unused.
