### PR TITLE
fix: Improve exception message for invalid collection type annotations

### DIFF
--- a/dataframely/exc.py
+++ b/dataframely/exc.py
@@ -104,7 +104,7 @@ class AnnotationImplementationError(ImplementationError):
         )
         if type(kls) is str:
             message += (
-                " Type annotation is a string, make sure you do not use "
+                " Type annotation is a string, make sure to not use "
                 "`from __future__ import annotations` in the file that defines the collection."
             )
         super().__init__(message)

--- a/dataframely/exc.py
+++ b/dataframely/exc.py
@@ -102,6 +102,11 @@ class AnnotationImplementationError(ImplementationError):
             "Annotations of a 'dy.Collection' may only be an (optional) "
             f"'dy.LazyFrame', but \"{attr}\" has type '{kls}'."
         )
+        if type(kls) is str:
+            message += (
+                " Type annotation is a string, make sure you do not use "
+                "`from __future__ import annotations` in the file that defines the collection."
+            )
         super().__init__(message)
 
 

--- a/tests/collection/test_collection_future_annotations.py
+++ b/tests/collection/test_collection_future_annotations.py
@@ -1,0 +1,24 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import (
+    annotations,  # This must not exist in files that define collections
+)
+
+import pytest
+
+import dataframely as dy
+from dataframely.exc import AnnotationImplementationError
+
+
+class MySchema(dy.Schema):
+    a = dy.Integer()
+
+
+def test_collection_future_annotations() -> None:
+    with pytest.raises(AnnotationImplementationError) as exception:
+
+        class MyCollection(dy.Collection):
+            member: dy.LazyFrame[MySchema]
+
+    assert "`from __future__ import annotations`" in str(exception.value)


### PR DESCRIPTION
# Motivation

I just ran into this and the exception message does not really help in understanding what is going on as you can't see that the type annotation it reads is a string. 
<img width="796" alt="Screenshot 2025-06-13 at 10 01 39" src="https://github.com/user-attachments/assets/5f1cbfea-4ce4-4d0f-a48c-0719165847e6" />

I thought it might be nice to explain a bit better.

# Changes

- Add additional explanation if the type annotation is an actual string, so that the parsing does not work, with explicit reference to future annotations, which might be the cause. 