### PR TITLE
feat: Introduce (de-)serialization for schemas

### DIFF
--- a/dataframely/__init__.py
+++ b/dataframely/__init__.py
@@ -51,7 +51,7 @@ from .functional import (
     filter_relationship_one_to_at_least_one,
     filter_relationship_one_to_one,
 )
-from .schema import Schema
+from .schema import Schema, load_schema
 
 __all__ = [
     "random",
@@ -67,6 +67,7 @@ __all__ = [
     "filter_relationship_one_to_at_least_one",
     "filter_relationship_one_to_one",
     "Schema",
+    "load_schema",
     "Any",
     "Bool",
     "Column",

--- a/dataframely/__init__.py
+++ b/dataframely/__init__.py
@@ -51,7 +51,7 @@ from .functional import (
     filter_relationship_one_to_at_least_one,
     filter_relationship_one_to_one,
 )
-from .schema import Schema, load_schema
+from .schema import Schema, deserialize_schema
 
 __all__ = [
     "random",
@@ -67,7 +67,7 @@ __all__ = [
     "filter_relationship_one_to_at_least_one",
     "filter_relationship_one_to_one",
     "Schema",
-    "load_schema",
+    "deserialize_schema",
     "Any",
     "Bool",
     "Column",

--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
+from typing import Any, Self
 
 import polars as pl
 
@@ -28,6 +29,19 @@ class Rule:
         """
         return self.expr.meta.eq(other.expr)
 
+    def encode(self) -> dict[str, Any]:
+        """Turn the rule into a dictionary."""
+        return {"rule_type": self.__class__.__name__, "expr": self.expr}
+
+    @classmethod
+    def decode(cls, data: dict[str, Any]) -> Self:
+        """Deserialize the rule from a dictionary.
+
+        Args:
+            data: The dictionary that was created via :meth:`asdict`.
+        """
+        return cls(data["expr"])
+
 
 class GroupRule(Rule):
     """Rule that is evaluated on a group of columns."""
@@ -40,6 +54,13 @@ class GroupRule(Rule):
         if not isinstance(other, GroupRule):
             return False
         return super().matches(other) and self.group_columns == other.group_columns
+
+    def encode(self) -> dict[str, Any]:
+        return {**super().encode(), "group_columns": self.group_columns}
+
+    @classmethod
+    def decode(cls, data: dict[str, Any]) -> Self:
+        return cls(data["expr"], group_columns=data["group_columns"])
 
 
 def rule(*, group_by: list[str] | None = None) -> Callable[[ValidationFunction], Rule]:
@@ -148,3 +169,30 @@ def _with_group_rules(lf: pl.LazyFrame, rules: dict[str, GroupRule]) -> pl.LazyF
             frame, on=list(group_columns), how="left", nulls_equal=True
         )
     return result
+
+
+# ------------------------------------------------------------------------------------ #
+#                                        FACTORY                                       #
+# ------------------------------------------------------------------------------------ #
+
+_TYPE_MAPPING: dict[str, type[Rule]] = {
+    Rule.__name__: Rule,
+    GroupRule.__name__: GroupRule,
+}
+
+
+def decode_rule(data: dict[str, Any]) -> Rule:
+    """Dynamically decode a rule object from a dictionary.
+
+    Args:
+        data: The dictionary obtained by calling :meth:`~Rule.ecnode` on a rule object.
+            The dictionary must contain a key ``"rule_type"`` that indicates which rule
+            type to instantiate.
+
+    Returns:
+        The rule object as decoded from ``data``.
+    """
+    name = data["rule_type"]
+    if name not in _TYPE_MAPPING:
+        raise ValueError(f"Unknown rule type: {name}")
+    return _TYPE_MAPPING[name].decode(data)

--- a/dataframely/_serialization.py
+++ b/dataframely/_serialization.py
@@ -1,0 +1,88 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+import datetime as dt
+import decimal
+from io import BytesIO
+from json import JSONDecoder, JSONEncoder
+from typing import Any, cast
+
+import polars as pl
+
+
+class SchemaJSONEncoder(JSONEncoder):
+    """Custom JSON encoder to properly serialize all types serialized by schemas."""
+
+    def encode(self, obj: Any) -> str:
+        def hint_tuples(item: Any) -> Any:
+            if isinstance(item, tuple):
+                return {"__type__": "tuple", "value": list(item)}
+            if isinstance(item, list):
+                return [hint_tuples(i) for i in item]
+            if isinstance(item, dict):
+                return {k: hint_tuples(v) for k, v in item.items()}
+            return item
+
+        return super().encode(hint_tuples(obj))
+
+    def default(self, obj: Any) -> Any:
+        match obj:
+            case pl.Expr():
+                return {
+                    "__type__": "expression",
+                    "value": obj.meta.serialize(format="json"),
+                }
+            case decimal.Decimal():
+                return {"__type__": "decimal", "value": str(obj)}
+            case dt.datetime():
+                return {"__type__": "datetime", "value": obj.isoformat()}
+            case dt.date():
+                return {"__type__": "date", "value": obj.isoformat()}
+            case dt.time():
+                return {"__type__": "time", "value": obj.isoformat()}
+            case dt.timedelta():
+                return {"__type__": "timedelta", "value": obj.total_seconds()}
+            case dt.tzinfo():
+                offset = obj.utcoffset(dt.datetime.now())
+                return {
+                    "__type__": "tzinfo",
+                    "value": offset.total_seconds() if offset is not None else None,
+                }
+            case _:
+                return super().default(obj)
+
+
+class SchemaJSONDecoder(JSONDecoder):
+    """Custom JSON decoder to properly deserialize all types serialized by schemas."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(object_hook=self.object_hook, *args, **kwargs)
+
+    def object_hook(self, dct: dict[str, Any]) -> Any:
+        if "__type__" not in dct:
+            return dct
+
+        match dct["__type__"]:
+            case "tuple":
+                return tuple(dct["value"])
+            case "expression":
+                data = BytesIO(cast(str, dct["value"]).encode("utf-8"))
+                return pl.Expr.deserialize(data, format="json")
+            case "decimal":
+                return decimal.Decimal(dct["value"])
+            case "datetime":
+                return dt.datetime.fromisoformat(dct["value"])
+            case "date":
+                return dt.date.fromisoformat(dct["value"])
+            case "time":
+                return dt.time.fromisoformat(dct["value"])
+            case "timedelta":
+                return dt.timedelta(seconds=float(dct["value"]))
+            case "tzinfo":
+                return (
+                    dt.timezone(dt.timedelta(seconds=float(dct["value"])))
+                    if dct["value"] is not None
+                    else dt.timezone(dt.timedelta(0))
+                )
+            case _:
+                raise TypeError(f"Unknown type '{dct['__type__']}' in JSON data.")

--- a/dataframely/columns/__init__.py
+++ b/dataframely/columns/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from ._base import Column
+from ._registry import decode_column
 from .any import Any
 from .array import Array
 from .bool import Bool
@@ -17,6 +18,7 @@ from .struct import Struct
 
 __all__ = [
     "Column",
+    "decode_column",
     "Any",
     "Array",
     "Bool",

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -7,7 +7,7 @@ import inspect
 from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import Any, Self, TypeAlias, cast
 
 import polars as pl
 
@@ -259,6 +259,71 @@ class Column(ABC):
         """Private utility for the null probability used during sampling."""
         return 0.1 if self.nullable else 0
 
+    # ----------------------------------- SERIALIZE ---------------------------------- #
+
+    def encode(self, expr: pl.Expr) -> dict[str, Any]:
+        """Encode the column definition into a dictionary.
+
+        If the column definition references other column definitions, they will be
+        turned into dictionaries recursively.
+
+        Args:
+            expr: An expression referencing the column to encode. This is required to
+                properly encode custom checks.
+
+        Returns:
+            The encoded column definition.
+
+        Note:
+            This method stores custom checks as expressions rather than callables to
+            allow for serialization.
+
+        Note:
+            Do NOT use the returned object to evaluate semantic equality of two columns.
+            It may yield different results than :meth:`matches`.
+
+        Attention:
+            This method is only intended for internal use.
+        """
+        from ._registry import _TYPE_MAPPING
+
+        if self.__class__.__name__ not in _TYPE_MAPPING:
+            raise ValueError("Cannot serialize non-native dataframely column types.")
+
+        return {
+            "column_type": self.__class__.__name__,
+            **{
+                param: (
+                    _check_to_expr(getattr(self, param), expr)
+                    if param == "check"
+                    else getattr(self, param)
+                )
+                for param in inspect.signature(self.__class__.__init__).parameters
+                if param not in ("self", "alias")
+            },
+        }
+
+    @classmethod
+    def decode(cls, data: dict[str, Any]) -> Self:
+        """Decode the column definition from a dictionary.
+
+        Args:
+            data: The dictionary that was created via :meth:`asdict`.
+
+        Returns:
+            The decoded column definition.
+
+        Attention:
+            This method is only intended for internal use.
+        """
+        return cls(
+            **{
+                k: (cast(Any, _check_from_expr(v)) if k == "check" else v)
+                for k, v in data.items()
+                if k != "column_type"
+            }
+        )
+
     # ----------------------------------- EQUALITY ----------------------------------- #
 
     def matches(self, other: Column, expr: pl.Expr) -> bool:
@@ -316,3 +381,29 @@ def _compare_checks(lhs: Check | None, rhs: Check | None, expr: pl.Expr) -> bool
             return lhs(expr).meta.eq(rhs(expr))
         case _:
             return False
+
+
+def _check_to_expr(check: Check | None, expr: pl.Expr) -> Any | None:
+    match check:
+        case None:
+            return None
+        case list():
+            return [c(expr) for c in check]
+        case dict():
+            return {key: c(expr) for key, c in check.items()}
+        case _ if callable(check):
+            return check(expr)
+
+
+def _check_from_expr(value: Any) -> Check | None:
+    match value:
+        case None:
+            return None
+        case list():
+            return [lambda _: c for c in value]
+        case dict():
+            return {key: lambda _: c for key, c in value.items()}
+        case pl.Expr():
+            return lambda _: value
+        case _:  # pragma: no cover
+            raise ValueError(f"Invalid type for check: {type(value)}")

--- a/dataframely/columns/_registry.py
+++ b/dataframely/columns/_registry.py
@@ -1,0 +1,32 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Any, TypeVar
+
+from ._base import Column
+
+C = TypeVar("C", bound=Column)
+
+_TYPE_MAPPING: dict[str, type[Column]] = {}
+
+
+def register(cls: type[C]) -> type[C]:
+    _TYPE_MAPPING[cls.__name__] = cls
+    return cls
+
+
+def decode_column(data: dict[str, Any]) -> Column:
+    """Dynamically decode a column from a dictionary.
+
+    Args:
+        data: The dictionary that was created by calling :meth:`~Column.encode` on a
+            column object. The dictionary must contain a key ``"column_type"`` that
+            indicates which column type to instantiate.
+
+    Returns:
+        The column object as decoded from ``data``.
+    """
+    name = data["column_type"]
+    if name not in _TYPE_MAPPING:
+        raise ValueError(f"Unknown column type: {name}")
+    return _TYPE_MAPPING[name].decode(data)

--- a/dataframely/columns/any.py
+++ b/dataframely/columns/any.py
@@ -10,8 +10,10 @@ from dataframely._polars import PolarsDataType
 from dataframely.random import Generator
 
 from ._base import Check, Column
+from ._registry import register
 
 
+@register
 class Any(Column):
     """A column with arbitrary type.
 

--- a/dataframely/columns/bool.py
+++ b/dataframely/columns/bool.py
@@ -9,10 +9,10 @@ from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely.random import Generator
 
 from ._base import Column
+from ._registry import register
 
-# ------------------------------------------------------------------------------------ #
 
-
+@register
 class Bool(Column):
     """A column of booleans."""
 

--- a/dataframely/columns/datetime.py
+++ b/dataframely/columns/datetime.py
@@ -21,11 +21,13 @@ from dataframely.random import Generator
 
 from ._base import Check, Column
 from ._mixins import OrdinalMixin
+from ._registry import register
 from ._utils import first_non_null, map_optional
 
 # ------------------------------------------------------------------------------------ #
 
 
+@register
 class Date(OrdinalMixin[dt.date], Column):
     """A column of dates (without time)."""
 
@@ -148,6 +150,7 @@ class Date(OrdinalMixin[dt.date], Column):
         )
 
 
+@register
 class Time(OrdinalMixin[dt.time], Column):
     """A column of times (without date)."""
 
@@ -276,6 +279,7 @@ class Time(OrdinalMixin[dt.time], Column):
         )
 
 
+@register
 class Datetime(OrdinalMixin[dt.datetime], Column):
     """A column of datetimes."""
 
@@ -422,6 +426,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
         return super()._attributes_match(lhs, rhs, name, column_expr)
 
 
+@register
 class Duration(OrdinalMixin[dt.timedelta], Column):
     """A column of durations."""
 

--- a/dataframely/columns/decimal.py
+++ b/dataframely/columns/decimal.py
@@ -15,9 +15,11 @@ from dataframely.random import Generator
 
 from ._base import Check, Column
 from ._mixins import OrdinalMixin
+from ._registry import register
 from ._utils import first_non_null, map_optional
 
 
+@register
 class Decimal(OrdinalMixin[decimal.Decimal], Column):
     """A column of decimal values with given precision and scale."""
 

--- a/dataframely/columns/enum.py
+++ b/dataframely/columns/enum.py
@@ -13,8 +13,10 @@ from dataframely._polars import PolarsDataType
 from dataframely.random import Generator
 
 from ._base import Check, Column
+from ._registry import register
 
 
+@register
 class Enum(Column):
     """A column of enum (string) values."""
 

--- a/dataframely/columns/float.py
+++ b/dataframely/columns/float.py
@@ -18,6 +18,7 @@ from dataframely.random import Generator
 
 from ._base import Check, Column
 from ._mixins import OrdinalMixin
+from ._registry import register
 from ._utils import classproperty, first_non_null, map_optional
 
 
@@ -140,6 +141,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
 # ------------------------------------------------------------------------------------ #
 
 
+@register
 class Float(_BaseFloat):
     """A column of floats (with any number of bytes)."""
 
@@ -166,6 +168,7 @@ class Float(_BaseFloat):
         return float(np.finfo(np.float64).min)
 
 
+@register
 class Float32(_BaseFloat):
     """A column of float32 ("float") values."""
 
@@ -189,6 +192,7 @@ class Float32(_BaseFloat):
         return float(np.finfo(np.float32).min)
 
 
+@register
 class Float64(_BaseFloat):
     """A column of float64 ("double") values."""
 

--- a/dataframely/columns/integer.py
+++ b/dataframely/columns/integer.py
@@ -16,6 +16,7 @@ from dataframely.random import Generator
 
 from ._base import Check, Column
 from ._mixins import IsInMixin, OrdinalMixin
+from ._registry import register
 from ._utils import classproperty, first_non_null, map_optional
 
 
@@ -145,6 +146,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
 # ------------------------------------------------------------------------------------ #
 
 
+@register
 class Integer(_BaseInteger):
     """A column of integers (with any number of bytes)."""
 
@@ -171,6 +173,7 @@ class Integer(_BaseInteger):
         return False
 
 
+@register
 class Int8(_BaseInteger):
     """A column of int8 values."""
 
@@ -194,6 +197,7 @@ class Int8(_BaseInteger):
         return False
 
 
+@register
 class Int16(_BaseInteger):
     """A column of int16 values."""
 
@@ -217,6 +221,7 @@ class Int16(_BaseInteger):
         return False
 
 
+@register
 class Int32(_BaseInteger):
     """A column of int32 values."""
 
@@ -240,6 +245,7 @@ class Int32(_BaseInteger):
         return False
 
 
+@register
 class Int64(_BaseInteger):
     """A column of int64 values."""
 
@@ -263,6 +269,7 @@ class Int64(_BaseInteger):
         return False
 
 
+@register
 class UInt8(_BaseInteger):
     """A column of uint8 values."""
 
@@ -292,6 +299,7 @@ class UInt8(_BaseInteger):
         return True
 
 
+@register
 class UInt16(_BaseInteger):
     """A column of uint16 values."""
 
@@ -315,6 +323,7 @@ class UInt16(_BaseInteger):
         return True
 
 
+@register
 class UInt32(_BaseInteger):
     """A column of uint32 values."""
 
@@ -338,6 +347,7 @@ class UInt32(_BaseInteger):
         return True
 
 
+@register
 class UInt64(_BaseInteger):
     """A column of uint64 values."""
 

--- a/dataframely/columns/object.py
+++ b/dataframely/columns/object.py
@@ -11,8 +11,10 @@ from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely.random import Generator
 
 from ._base import Check, Column
+from ._registry import register
 
 
+@register
 class Object(Column):
     """A Python Object column."""
 

--- a/dataframely/columns/string.py
+++ b/dataframely/columns/string.py
@@ -12,10 +12,10 @@ from dataframely._extre import matching_string_length as extre_matching_string_l
 from dataframely.random import Generator
 
 from ._base import Check, Column
+from ._registry import register
 
-# ------------------------------------------------------------------------------------ #
 
-
+@register
 class String(Column):
     """A column of strings."""
 

--- a/dataframely/columns/struct.py
+++ b/dataframely/columns/struct.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import polars as pl
 
@@ -12,8 +12,10 @@ from dataframely._polars import PolarsDataType
 from dataframely.random import Generator
 
 from ._base import Check, Column
+from ._registry import decode_column, register
 
 
+@register
 class Struct(Column):
     """A struct column."""
 
@@ -130,3 +132,18 @@ class Struct(Column):
                 for field in lhs
             )
         return super()._attributes_match(lhs, rhs, name, column_expr)
+
+    def encode(self, expr: pl.Expr) -> dict[str, Any]:
+        result = super().encode(expr)
+        result["inner"] = {
+            name: col.encode(expr.struct.field(name))
+            for name, col in self.inner.items()
+        }
+        return result
+
+    @classmethod
+    def decode(cls, data: dict[str, Any]) -> Self:
+        data["inner"] = {
+            name: decode_column(col) for name, col in data["inner"].items()
+        }
+        return super().decode(data)

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -696,7 +696,7 @@ class Schema(BaseSchema, ABC):
         )
 
 
-def load_schema(data: str) -> type[Schema]:
+def deserialize_schema(data: str) -> type[Schema]:
     """Deserialize a schema from a JSON string.
 
     This method allows to dynamically load a schema from its serialization, without

--- a/tests/schema/test_serialization.py
+++ b/tests/schema/test_serialization.py
@@ -1,0 +1,129 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+import datetime as dt
+import json
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+import dataframely as dy
+from dataframely._rule import GroupRule, Rule
+from dataframely.testing import create_schema
+
+
+def test_simple_serialization() -> None:
+    # Arrange
+    schema = create_schema("test", {"a": dy.Int64()})
+
+    # Act
+    serialized = schema.serialize()
+
+    # Assert
+    decoded = json.loads(serialized)
+    assert decoded["versions"]["format"] == "1"
+    assert decoded["name"] == "test"
+    assert set(decoded["columns"].keys()) == {"a"}
+    assert set(decoded["rules"].keys()) == set()
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        create_schema("test", {}),
+        create_schema("test", {"a": dy.Int64()}),
+        create_schema("test", {"a": dy.Int64(min=3, max=5)}),
+        create_schema("test", {"a": dy.Int64(check=lambda expr: expr > 5)}),
+        create_schema("test", {"a": dy.Int64(check=[lambda expr: expr > 5])}),
+        create_schema("test", {"a": dy.Int64(check={"x": lambda expr: expr > 5})}),
+        create_schema("test", {"a": dy.Int64(alias="foo")}),
+        create_schema("test", {"a": dy.Decimal(scale=2, min=Decimal("1.5"))}),
+        create_schema("test", {"a": dy.Date(min=dt.date(2020, 1, 1))}),
+        create_schema("test", {"a": dy.Datetime(min=dt.datetime(2020, 1, 1))}),
+        create_schema("test", {"a": dy.Time(min=dt.time(10))}),
+        create_schema("test", {"a": dy.Duration(min=dt.timedelta(milliseconds=10))}),
+        create_schema("test", {"a": dy.Datetime(time_zone=ZoneInfo("Europe/Berlin"))}),
+        create_schema("test", {"a": dy.Int64()}, rules={"test": Rule(pl.col("a") > 5)}),
+        create_schema(
+            "test",
+            {"a": dy.Int64()},
+            rules={"test": GroupRule(pl.len() > 2, group_columns=["a"])},
+        ),
+        create_schema("test", {"a": dy.Array(dy.Int64(), shape=(2, 2))}),
+        create_schema("test", {"a": dy.List(dy.Int64(min=5))}),
+        create_schema(
+            "test",
+            {"a": dy.Struct({"x": dy.Int64(min=5, check=lambda expr: expr < 10)})},
+        ),
+    ],
+)
+def test_roundtrip_matches(schema: type[dy.Schema]) -> None:
+    serialized = schema.serialize()
+    decoded = dy.load_schema(serialized)
+    assert schema.matches(decoded)
+
+
+# ------------------------------ SERIALIZATION FAILURES ------------------------------ #
+
+
+def test_serialize_invalid_type() -> None:
+    schema = create_schema(
+        "test", {"a": dy.Int64(metadata={"invalid": type("foo", (object,), {})})}
+    )
+    with pytest.raises(TypeError):
+        schema.serialize()
+
+
+def test_serialize_column_subclass() -> None:
+    class CustomColumn(dy.Int64):
+        pass
+
+    schema = create_schema("test", {"a": CustomColumn()})
+    with pytest.raises(ValueError):
+        schema.serialize()
+
+
+# ----------------------------- DESERIALIZATION FAILURES ----------------------------- #
+
+
+def test_deserialize_unknown_column_type() -> None:
+    serialized = """
+        {
+            "versions": {"format": "1", "dataframely": "0.0.0", "polars": "1.30.0"},
+            "name": "test",
+            "columns": {"a": {"column_type": "unknown"}},
+            "rules": {}
+        }
+    """
+    with pytest.raises(ValueError):
+        dy.load_schema(serialized)
+
+
+def test_deserialize_unknown_rule_type() -> None:
+    serialized = """
+        {
+            "versions": {"format": "1", "dataframely": "0.0.0", "polars": "1.30.0"},
+            "name": "test",
+            "columns": {},
+            "rules": {"a": {"rule_type": "unknown"}}
+        }
+    """
+    with pytest.raises(ValueError):
+        dy.load_schema(serialized)
+
+
+def test_deserialize_invalid_type() -> None:
+    serialized = '{"__type__": "unknown", "value": "foo"}'
+    with pytest.raises(TypeError):
+        dy.load_schema(serialized)
+
+
+# ---------------------------------- OTHER FAILURES ---------------------------------- #
+
+
+def test_deserialize_unknown_format_version() -> None:
+    serialized = '{"versions": {"format": "invalid"}}'
+    with pytest.raises(ValueError, match=r"Unsupported schema format version"):
+        dy.load_schema(serialized)

--- a/tests/schema/test_serialization.py
+++ b/tests/schema/test_serialization.py
@@ -61,7 +61,7 @@ def test_simple_serialization() -> None:
 )
 def test_roundtrip_matches(schema: type[dy.Schema]) -> None:
     serialized = schema.serialize()
-    decoded = dy.load_schema(serialized)
+    decoded = dy.deserialize_schema(serialized)
     assert schema.matches(decoded)
 
 
@@ -98,7 +98,7 @@ def test_deserialize_unknown_column_type() -> None:
         }
     """
     with pytest.raises(ValueError):
-        dy.load_schema(serialized)
+        dy.deserialize_schema(serialized)
 
 
 def test_deserialize_unknown_rule_type() -> None:
@@ -111,13 +111,13 @@ def test_deserialize_unknown_rule_type() -> None:
         }
     """
     with pytest.raises(ValueError):
-        dy.load_schema(serialized)
+        dy.deserialize_schema(serialized)
 
 
 def test_deserialize_invalid_type() -> None:
     serialized = '{"__type__": "unknown", "value": "foo"}'
     with pytest.raises(TypeError):
-        dy.load_schema(serialized)
+        dy.deserialize_schema(serialized)
 
 
 # ---------------------------------- OTHER FAILURES ---------------------------------- #
@@ -126,4 +126,4 @@ def test_deserialize_invalid_type() -> None:
 def test_deserialize_unknown_format_version() -> None:
     serialized = '{"versions": {"format": "invalid"}}'
     with pytest.raises(ValueError, match=r"Unsupported schema format version"):
-        dy.load_schema(serialized)
+        dy.deserialize_schema(serialized)


### PR DESCRIPTION
# Motivation

When serializing data frames to parquet, schema information beyond the simple polars schema is currently lost. However, persisting the schema alongside has multiple potential benefits:

- When reading the parquet file, schema information can be used to check whether the data adheres to the current schema without having to validate.
- Third-party tools can use advanced schema information to optimize operations

Since polars 1.30, the parquet writer supports writing file-level metadata. Naturally, dataframely schemas could be serialized as such.

This PR is the first step towards doing that: it introduces (de-)serialization for schemas from & to JSON.

# Changes

- Introduce `Schema.serialize` and `dy.deserialize_schema` to serialize and de-serialize schemas to and from JSON
