### PR TITLE
feat: Add lazy rules

### DIFF
--- a/dataframely/__init__.py
+++ b/dataframely/__init__.py
@@ -13,7 +13,7 @@ except importlib.metadata.PackageNotFoundError as e:  # pragma: no cover
 from . import random
 from ._base_collection import CollectionMember
 from ._filter import filter
-from ._rule import rule
+from ._rule import lazy_rule, rule
 from ._typing import DataFrame, LazyFrame
 from .collection import Collection
 from .columns import (
@@ -57,6 +57,7 @@ __all__ = [
     "random",
     "filter",
     "rule",
+    "lazy_rule",
     "DataFrame",
     "LazyFrame",
     "Collection",

--- a/dataframely/__init__.py
+++ b/dataframely/__init__.py
@@ -13,7 +13,7 @@ except importlib.metadata.PackageNotFoundError as e:  # pragma: no cover
 from . import random
 from ._base_collection import CollectionMember
 from ._filter import filter
-from ._rule import lazy_rule, rule
+from ._rule import rule
 from ._typing import DataFrame, LazyFrame
 from .collection import Collection
 from .columns import (
@@ -57,7 +57,6 @@ __all__ = [
     "random",
     "filter",
     "rule",
-    "lazy_rule",
     "DataFrame",
     "LazyFrame",
     "Collection",

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -120,8 +120,13 @@ class SchemaMeta(ABCMeta):
             )
             # NOTE: For some reason, `polars` does not yield correct dtypes when calling
             #  `collect_schema()`
-            schema = with_evaluation_rules(lf_empty, result.rules).collect().schema
+            schema = (
+                with_evaluation_rules(lf_empty, result.rules, None).collect().schema
+            )
             for rule_name, rule in result.rules.items():
+                if rule_name not in schema:
+                    # Lazy rules will not be evaluated at this point.
+                    continue
                 dtype = schema[rule_name]
                 if not isinstance(dtype, pl.Boolean):
                     raise RuleImplementationError(

--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -80,6 +80,26 @@ def rule(
 def lazy_rule(
     *, group_by: list[str] | None = None
 ) -> Callable[[LazyValidationFunction], Rule]:
+    """Mark a function as a rule to evaluate during validation.
+
+    This does the same as `rule`, but allows for lazy evaluation of rules. This means the
+    dtype of the returned expression is not validated to be a boolean expression! Use this
+    method if you need to access the schema class in your rule function, want to use
+    `@classmethod` on the rule or need to access constants defined after the schema.
+
+    Args:
+        group_by: An optional list of columns to group by for rules operating on groups
+            of rows. If this list is provided, the returned expression must return a
+            single boolean value, i.e. some kind of aggregation function must be used
+            (e.g. ``sum``, ``any``, ...).
+
+    Note:
+        You'll need to explicitly handle ``null`` values in your columns when defining
+        rules. By default, any rule that evaluates to ``null`` because one of the
+        columns used in the rule is ``null`` is interpreted as ``true``, i.e. the row
+        is assumed to be valid.
+    """
+
     def decorator(validation_fn: LazyValidationFunction) -> Rule:
         if group_by is not None:
             return GroupRule(

--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -89,39 +89,6 @@ def rule(
     return decorator
 
 
-def lazy_rule(
-    *, group_by: list[str] | None = None
-) -> Callable[[LazyValidationFunction], Rule]:
-    """Mark a function as a rule to evaluate during validation.
-
-    This does the same as `rule`, but allows for lazy evaluation of rules. This means the
-    dtype of the returned expression is not validated to be a boolean expression! Use this
-    method if you need to access the schema class in your rule function, want to use
-    `@classmethod` on the rule or need to access constants defined after the schema.
-
-    Args:
-        group_by: An optional list of columns to group by for rules operating on groups
-            of rows. If this list is provided, the returned expression must return a
-            single boolean value, i.e. some kind of aggregation function must be used
-            (e.g. ``sum``, ``any``, ...).
-
-    Note:
-        You'll need to explicitly handle ``null`` values in your columns when defining
-        rules. By default, any rule that evaluates to ``null`` because one of the
-        columns used in the rule is ``null`` is interpreted as ``true``, i.e. the row
-        is assumed to be valid.
-    """
-
-    def decorator(validation_fn: LazyValidationFunction) -> Rule:
-        if group_by is not None:
-            return GroupRule(
-                expr_or_validation_fn=validation_fn, group_columns=group_by
-            )
-        return Rule(expr_or_validation_fn=validation_fn)
-
-    return decorator
-
-
 # ------------------------------------------------------------------------------------ #
 #                                      EVALUATION                                      #
 # ------------------------------------------------------------------------------------ #

--- a/dataframely/mypy.py
+++ b/dataframely/mypy.py
@@ -44,7 +44,6 @@ from mypy.types import (
 COLLECTION_FULLNAME = "dataframely.collection.Collection"
 COLUMN_PACKAGE = "dataframely.column"
 RULE_DECORATOR_FULLNAME = "dataframely._rule.rule"
-LAZY_RULE_DECORATOR_FULLNAME = "dataframely._rule.lazy_rule"
 CLASSMETHOD_FULLNAME = "builtins.classmethod"
 SCHEMA_FULLNAME = "dataframely.schema.Schema"
 TYPED_DATAFRAME_FULLNAME = "dataframely._typing.DataFrame"
@@ -65,8 +64,6 @@ def mark_rules_as_staticmethod(ctx: ClassDefContext) -> None:
         if not isinstance(decorator.callee, MemberExpr):
             continue
         if decorator.callee.fullname == RULE_DECORATOR_FULLNAME:
-            sym.node.func.is_static = True
-        if decorator.callee.fullname == LAZY_RULE_DECORATOR_FULLNAME:
             sym.node.func.is_class = any(
                 CLASSMETHOD_FULLNAME == dec.fullname
                 for dec in sym.node.original_decorators

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -489,7 +489,7 @@ class Schema(BaseSchema, ABC):
             rules.update(dtype_rules)
 
         if len(rules) > 0:
-            lf_with_eval = with_evaluation_rules(lf, rules)
+            lf_with_eval = with_evaluation_rules(lf, rules, cls)
             if cast:
                 # If we cast dtypes, we need to take care of two things:
                 # - There's still a bunch of columns showing the original nullability in the

--- a/tests/core_validation/test_rule_evaluation.py
+++ b/tests/core_validation/test_rule_evaluation.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import polars as pl
+import pytest
 from polars.testing import assert_frame_equal
 
-from dataframely._rule import GroupRule, Rule
+from dataframely._rule import GroupRule, Rule, rule
 from dataframely.testing import evaluate_rules
 
 
@@ -106,3 +107,16 @@ def test_multiple_group_rules() -> None:
         }
     )
     assert_frame_equal(actual, expected)
+
+
+def test_rule_with_classmethod() -> None:
+    with pytest.raises(
+        ValueError,
+        match="Using `@classmethod` on a rule requires `lazy=True` to be set.",
+    ):
+
+        class _MySchema:
+            @rule()
+            @classmethod
+            def _test_method(cls) -> pl.Expr:
+                return pl.col("a") > 0

--- a/tests/schema/test_validate.py
+++ b/tests/schema/test_validate.py
@@ -32,11 +32,11 @@ class MyComplexSchemaWithLazyRules(dy.Schema):
     a = dy.Int64()
     b = dy.Int64()
 
-    @dy.lazy_rule()
+    @dy.rule(lazy=True)
     def b_greater_a() -> pl.Expr:
         return MyComplexSchemaWithLazyRules.b.col > MyComplexSchemaWithLazyRules.a.col
 
-    @dy.lazy_rule(group_by=["a"])
+    @dy.rule(lazy=True, group_by=["a"])
     @classmethod
     def b_unique_within_a(cls) -> pl.Expr:
         return cls.b.col.n_unique() == SOME_CONSTANT_DEFINED_LATER

--- a/tests/schema/test_validate.py
+++ b/tests/schema/test_validate.py
@@ -33,15 +33,16 @@ class MyComplexSchemaWithLazyRules(dy.Schema):
     b = dy.Int64()
 
     @dy.lazy_rule()
-    @classmethod
-    def b_greater_a(cls) -> pl.Expr:
-        return cls.b.col > cls.a.col
+    def b_greater_a() -> pl.Expr:
+        return MyComplexSchemaWithLazyRules.b.col > MyComplexSchemaWithLazyRules.a.col
 
     @dy.lazy_rule(group_by=["a"])
     @classmethod
     def b_unique_within_a(cls) -> pl.Expr:
-        return cls.b.col.n_unique() == 1
+        return cls.b.col.n_unique() == SOME_CONSTANT_DEFINED_LATER
 
+
+SOME_CONSTANT_DEFINED_LATER = 1
 
 # -------------------------------------- COLUMNS ------------------------------------- #
 


### PR DESCRIPTION
# Motivation

This is a rough draft to solve #59.

# Changes

This adds another annotation `@dy.lazy_rule()` that works like `@dy.rule()` but defers evaluation of the wrapped method until a dataframe is actually verified.

As @borchero pointed out, we cant defer the eager evaluation of `@dy.rule` without dropping the check that rules return expressions of dtype boolean. `@dy.lazy_rule()` was introduced as an extra annotation in order to keep error messages on `@dy.rule` the same.
