### PR TITLE
feat: Enable custom data frame pre-processing during schema sampling

### DIFF
--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -358,19 +358,17 @@ class Schema(BaseSchema, ABC):
 
     @classmethod
     def _preprocess_dataframe_hook(cls) -> dict[str, pl.Expr]:
-        """Hook for pre-processing a data frame that is generated in a sampling
-        iteration before filtering or validation. This method can be overwritten in
-        schemas with complex rules or column checks to enable sampling data frames in a
-        reasonable number of iterations.
-
-        Args:
-            df: The data frame to post-process. This data frame is guaranteed to
-                contain all columns defined in the schema with the correct data types,
-                but does not necessarily fulfill custom rules or column checks.
+        """Hook for providing column-wise expressions for pre-processing a data frame
+        that is generated in a sampling iteration before filtering or validation. The
+        provided expressions are applied to all columns of a sampled data frame that are
+        not defined in the `overrides` argument of :meth:`sample`. This method can be
+        overwritten in schemas with complex rules or column checks to enable sampling
+        data frames in a reasonable number of iterations.
 
         Returns:
-            The pre-processed data frame.
+            A dict with entries `column_name: expression`.
         """
+        # Do not pre-process any columns by default.
         return dict()
 
     # ---------------------------------- VALIDATION ---------------------------------- #

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -363,7 +363,7 @@ class Schema(BaseSchema, ABC):
         """Generate expressions for columns that need to be pre-processed during
         sampling.
 
-        This method can be overwritten in schemas with complex rules or column checks to
+        This method can be overwritten in schemas with complex rules to
         enable sampling data frames in a reasonable number of iterations.
 
         The provided expressions are applied during sampling after data was generated and

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -243,6 +243,7 @@ class Schema(BaseSchema, ABC):
                 "The schema defines `_sampling_overrides` for columns that are not in the "
                 f"schema: {superfluous_overrides}."
             )
+
         override_expressions = [
             # Cast needed as column pre-processing might change the data types of a column
             expr.cast(cls.columns()[col].dtype).alias(col)

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -275,7 +275,8 @@ class Schema(BaseSchema, ABC):
                     "iterations. Consider increasing the maximum number of sampling "
                     "iterations via `dy.Config` or implement your custom sampling "
                     "logic. Alternatively, passing predefined value to `overrides` "
-                    "can also help the sampling procedure find a valid data frame."
+                    "or implementing `_sampling_overrides` for your schema can also "
+                    "help the sampling procedure find a valid data frame."
                 )
             result, used_values, remaining_values = cls._sample_filter(
                 num_rows - len(result),

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -328,7 +328,7 @@ class Schema(BaseSchema, ABC):
         if column_preprocessing_expressions:
             combined_dataframe = combined_dataframe.with_columns(
                 # Cast needed as column pre-processing might change the data types of a column
-                expr.alias(col).cast(cls.columns()[col].dtype)
+                expr.cast(cls.columns()[col].dtype).alias(col)
                 for col, expr in column_preprocessing_expressions.items()
             )
 
@@ -374,7 +374,7 @@ class Schema(BaseSchema, ABC):
             A dict with entries `column_name: expression`.
         """
         # Do not pre-process any columns by default.
-        return dict()
+        return {}
 
     # ---------------------------------- VALIDATION ---------------------------------- #
 

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -317,8 +317,8 @@ class Schema(BaseSchema, ABC):
             }
         )
 
-        # Call custom sampling hook to allow for post-processing of the sampled data
-        sampled = cls.cast(cls._sample_postprocess_hook(sampled))
+        # Call custom sampling hook to allow for pre-processing of the sampled data
+        sampled = cls.cast(cls._preprocess_dataframe_hook(sampled))
 
         # NOTE: We already know that all columns have the correct dtype
         rules = cls._validation_rules()
@@ -348,19 +348,19 @@ class Schema(BaseSchema, ABC):
         )
 
     @classmethod
-    def _sample_postprocess_hook(cls, df: pl.DataFrame) -> pl.DataFrame:
-        """Hook for post-processing data frames that are generated in a sampling
+    def _preprocess_dataframe_hook(cls, df: pl.DataFrame) -> pl.DataFrame:
+        """Hook for pre-processing a data frame that is generated in a sampling
         iteration before filtering or validation. This method can be overwritten in
-        schemas with complex rules or checks to enabling sampling data frames in a
+        schemas with complex rules or column checks to enable sampling data frames in a
         reasonable number of iterations.
 
         Args:
             df: The data frame to post-process. This data frame is guaranteed to
-                contain all columns defined in the schema and their data types,
-                but not to fulfill custom rules or checks.
+                contain all columns defined in the schema with the correct data types,
+                but does not necessarily fulfill custom rules or column checks.
 
         Returns:
-            The post-processed data frame.
+            The pre-processed data frame.
         """
         return df
 

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -317,7 +317,8 @@ class Schema(BaseSchema, ABC):
             }
         )
 
-        sampled = cls._sample_postprocess_hook(sampled)
+        # Call custom sampling hook to allow for post-processing of the sampled data
+        sampled = cls.cast(cls._sample_postprocess_hook(sampled))
 
         # NOTE: We already know that all columns have the correct dtype
         rules = cls._validation_rules()
@@ -356,14 +357,10 @@ class Schema(BaseSchema, ABC):
         Args:
             df: The data frame to post-process. This data frame is guaranteed to
                 contain all columns defined in the schema and their data types,
-                but not to fulfill custom rules or checks
+                but not to fulfill custom rules or checks.
 
         Returns:
             The post-processed data frame.
-
-        Note: This method does not have to create schema-compliant
-            data frames yet, but the column types must match the
-            schema.
         """
         return df
 

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -317,6 +317,8 @@ class Schema(BaseSchema, ABC):
             }
         )
 
+        sampled = cls._sample_postprocess_hook(sampled)
+
         # NOTE: We already know that all columns have the correct dtype
         rules = cls._validation_rules()
         filtered, evaluated = cls._filter_raw(
@@ -343,6 +345,27 @@ class Schema(BaseSchema, ABC):
             concat_values.filter(evaluated.get_column("__final_valid__")),
             concat_values.filter(~evaluated.get_column("__final_valid__")),
         )
+
+    @classmethod
+    def _sample_postprocess_hook(cls, df: pl.DataFrame) -> pl.DataFrame:
+        """Hook for post-processing data frames that are generated in a sampling
+        iteration before filtering or validation. This method can be overwritten in
+        schemas with complex rules or checks to enabling sampling data frames in a
+        reasonable number of iterations.
+
+        Args:
+            df: The data frame to post-process. This data frame is guaranteed to
+                contain all columns defined in the schema and their data types,
+                but not to fulfill custom rules or checks
+
+        Returns:
+            The post-processed data frame.
+
+        Note: This method does not have to create schema-compliant
+            data frames yet, but the column types must match the
+            schema.
+        """
+        return df
 
     # ---------------------------------- VALIDATION ---------------------------------- #
 

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -321,7 +321,7 @@ class Schema(BaseSchema, ABC):
         # If needed, pre-process columns of the new data frame.
         column_preprocessing_expressions = {
             col: expr
-            for col, expr in cls._preprocess_dataframe_hook().items()
+            for col, expr in cls._column_preprocessing_expressions().items()
             # Only pre-process columns that were not provided through `overrides`
             if col in combined_dataframe.columns and col not in remaining_values.columns
         }
@@ -359,13 +359,16 @@ class Schema(BaseSchema, ABC):
         )
 
     @classmethod
-    def _preprocess_dataframe_hook(cls) -> dict[str, pl.Expr]:
-        """Hook for providing column-wise expressions for pre-processing a data frame
-        that is generated in a sampling iteration before filtering or validation. The
-        provided expressions are applied to all columns of a sampled data frame that are
-        not defined in the `overrides` argument of :meth:`sample`. This method can be
-        overwritten in schemas with complex rules or column checks to enable sampling
-        data frames in a reasonable number of iterations.
+    def _column_preprocessing_expressions(cls) -> dict[str, pl.Expr]:
+        """Generate expressions for columns that need to be pre-processed during
+        sampling.
+
+        This method can be overwritten in schemas with complex rules or column checks to
+        enable sampling data frames in a reasonable number of iterations.
+
+        The provided expressions are applied during sampling after data was generated and
+        before it is filtered. In a sampling iteration, only expressions cor columns
+        that are not defined in the `overrides` argument of that operation.
 
         Returns:
             A dict with entries `column_name: expression`.

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -155,7 +155,7 @@ def test_sample_no_overrides_no_num_rows() -> None:
     assert len(df) == 1
 
 
-def test_sample_ordered() -> None:
+def test_sample_ordered_works_with_hook() -> None:
     df = OrderedSchema.sample(1000)
     OrderedSchema.validate(df)
     assert len(df) == 1000

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -200,8 +200,9 @@ def test_sample_preprocessing_data_type_change() -> None:
     assert len(df) == 100
 
 
-def test_sample_preprocessing_invalid_column() -> None:
-    df = SchemaWithIrrelevantColumnPreProcessing.sample(100)
-
-    SchemaWithIrrelevantColumnPreProcessing.validate(df)
-    assert len(df) == 100
+def test_sample_raises_superfluous_column_override() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"`_sampling_overrides` for columns that are not in the schema",
+    ):
+        SchemaWithIrrelevantColumnPreProcessing.sample(100)

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -69,7 +69,7 @@ class OrderedSchema(dy.Schema):
         ).all()
 
     @classmethod
-    def _preprocess_dataframe_hook(cls) -> dict[str, pl.Expr]:
+    def _column_preprocessing_expressions(cls) -> dict[str, pl.Expr]:
         # Ensure that the `iter` column is ordered
         return {"iter": pl.struct("a", "b").rank(method="ordinal")}
 
@@ -79,7 +79,7 @@ class SchemaWithTypeChangingOverrides(dy.Schema):
     b = dy.String()
 
     @classmethod
-    def _preprocess_dataframe_hook(cls) -> dict[str, pl.Expr]:
+    def _column_preprocessing_expressions(cls) -> dict[str, pl.Expr]:
         return {"a": pl.col("a").cast(pl.String())}
 
 
@@ -87,7 +87,7 @@ class SchemaWithIrrelevantColumnPreProcessing(dy.Schema):
     a = dy.UInt8()
 
     @classmethod
-    def _preprocess_dataframe_hook(cls) -> dict[str, pl.Expr]:
+    def _column_preprocessing_expressions(cls) -> dict[str, pl.Expr]:
         return {"irrelevant_column": pl.col("irrelevant_column").cast(pl.String())}
 
 

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -69,7 +69,7 @@ class OrderedSchema(dy.Schema):
         ).all()
 
     @classmethod
-    def _column_preprocessing_expressions(cls) -> dict[str, pl.Expr]:
+    def _sampling_overrides(cls) -> dict[str, pl.Expr]:
         # Ensure that the `iter` column is ordered
         return {"iter": pl.struct("a", "b").rank(method="ordinal")}
 
@@ -79,7 +79,7 @@ class SchemaWithTypeChangingOverrides(dy.Schema):
     b = dy.String()
 
     @classmethod
-    def _column_preprocessing_expressions(cls) -> dict[str, pl.Expr]:
+    def _sampling_overrides(cls) -> dict[str, pl.Expr]:
         return {"a": pl.col("a").cast(pl.String())}
 
 
@@ -87,7 +87,7 @@ class SchemaWithIrrelevantColumnPreProcessing(dy.Schema):
     a = dy.UInt8()
 
     @classmethod
-    def _column_preprocessing_expressions(cls) -> dict[str, pl.Expr]:
+    def _sampling_overrides(cls) -> dict[str, pl.Expr]:
         return {"irrelevant_column": pl.col("irrelevant_column").cast(pl.String())}
 
 

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -69,7 +69,7 @@ class OrderedSchema(dy.Schema):
         ).all()
 
     @classmethod
-    def _sample_postprocess_hook(cls, df: pl.DataFrame) -> pl.DataFrame:
+    def _preprocess_dataframe_hook(cls, df: pl.DataFrame) -> pl.DataFrame:
         # Ensure that the `iter` column is ordered
         return df.with_columns(iter=pl.struct("a", "b").rank(method="ordinal"))
 
@@ -156,6 +156,7 @@ def test_sample_no_overrides_no_num_rows() -> None:
 
 
 def test_sample_ordered_works_with_hook() -> None:
-    df = OrderedSchema.sample(1000)
-    OrderedSchema.validate(df)
-    assert len(df) == 1000
+    for _ in range(100):
+        df = OrderedSchema.sample(1000)
+        OrderedSchema.validate(df)
+        assert len(df) == 1000

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -167,9 +167,10 @@ def test_sample_ordered_works_with_overrides() -> None:
         overrides={
             "a": [1, 4, 2, 5, 5],
             "b": [1, 2, 3, 4, 0],
-            "iter": [1, 3, 2, 5, 4],
+            "iter": [2, 6, 4, 10, 8],
         }
     )
     OrderedSchema.validate(df)
     assert len(df) == 5
-    assert df.get_column("iter").to_list() == [1, 3, 2, 5, 4]
+    # Assert that the hook is not used (would create 1..5 permutation)
+    assert df.get_column("iter").to_list() == [2, 6, 4, 10, 8]

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -71,9 +71,7 @@ class OrderedSchema(dy.Schema):
     @classmethod
     def _sample_postprocess_hook(cls, df: pl.DataFrame) -> pl.DataFrame:
         # Ensure that the `iter` column is ordered
-        return df.with_columns(
-            iter=pl.struct("a", "b").rank(method="ordinal").cast(pl.Int64())
-        )
+        return df.with_columns(iter=pl.struct("a", "b").rank(method="ordinal"))
 
 
 # --------------------------------------- TESTS -------------------------------------- #

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -156,6 +156,6 @@ def test_sample_no_overrides_no_num_rows() -> None:
 
 
 def test_sample_ordered() -> None:
-    df = OrderedSchema.sample(1000, generator=Generator(seed=42))
+    df = OrderedSchema.sample(1000)
     OrderedSchema.validate(df)
     assert len(df) == 1000

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -83,6 +83,14 @@ class SchemaWithTypeChangingOverrides(dy.Schema):
         return {"a": pl.col("a").cast(pl.String())}
 
 
+class SchemaWithIrrelevantColumnPreProcessing(dy.Schema):
+    a = dy.UInt8()
+
+    @classmethod
+    def _preprocess_dataframe_hook(cls) -> dict[str, pl.Expr]:
+        return {"irrelevant_column": pl.col("irrelevant_column").cast(pl.String())}
+
+
 # --------------------------------------- TESTS -------------------------------------- #
 
 
@@ -185,8 +193,15 @@ def test_sample_ordered_works_with_overrides() -> None:
     assert df.get_column("iter").to_list() == [2, 6, 4, 10, 8]
 
 
-def test_sample_overrides_data_type_change() -> None:
+def test_sample_preprocessing_data_type_change() -> None:
     df = SchemaWithTypeChangingOverrides.sample(100)
 
     SchemaWithTypeChangingOverrides.validate(df)
+    assert len(df) == 100
+
+
+def test_sample_preprocessing_invalid_column() -> None:
+    df = SchemaWithIrrelevantColumnPreProcessing.sample(100)
+
+    SchemaWithIrrelevantColumnPreProcessing.validate(df)
     assert len(df) == 100


### PR DESCRIPTION
# Motivation

See #72. 

# Changes

- Added `Schema._sampling_overrides` to allow setting custom column pre-processing expressions
- Extended sampling logic to apply those expressions where needed
- Added tests

Fixes #72