### PR TITLE
refactor: Move `Validation` to public API

### DIFF
--- a/dataframely/__init__.py
+++ b/dataframely/__init__.py
@@ -14,7 +14,7 @@ from . import random
 from ._base_collection import CollectionMember
 from ._filter import filter
 from ._rule import rule
-from ._typing import DataFrame, LazyFrame
+from ._typing import DataFrame, LazyFrame, Validation
 from .collection import Collection, deserialize_collection
 from .columns import (
     Any,
@@ -96,4 +96,5 @@ __all__ = [
     "List",
     "Array",
     "Object",
+    "Validation",
 ]


### PR DESCRIPTION
# Motivation

If one wants to override functions from the public API of `dy.Schema` or `dy.Collection`, the `Validation` literal type should also be exposed.

# Changes

Add `Validation` to public API.
