### PR TITLE
fix: Only warn about nullability on non-primary-key columns

### DIFF
--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -75,12 +75,13 @@ class Column(ABC):
 
         if nullable and primary_key:
             warn_no_nullable_primary_keys()
+            nullable = False
 
         if nullable is None and not primary_key:
             warn_nullable_default_change()
             nullable = True
 
-        self.nullable = nullable and not primary_key
+        self.nullable = nullable
         self.primary_key = primary_key
         self.check = check
         self.alias = alias

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -77,9 +77,12 @@ class Column(ABC):
             warn_no_nullable_primary_keys()
             nullable = False
 
-        if nullable is None and not primary_key:
-            warn_nullable_default_change()
-            nullable = True
+        if nullable is None:
+            if primary_key:
+                nullable = False
+            else:
+                warn_nullable_default_change()
+                nullable = True
 
         self.nullable = nullable
         self.primary_key = primary_key

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -76,7 +76,7 @@ class Column(ABC):
         if nullable and primary_key:
             warn_no_nullable_primary_keys()
 
-        if nullable is None:
+        if nullable is None and not primary_key:
             warn_nullable_default_change()
             nullable = True
 


### PR DESCRIPTION
# Motivation

The current FutureWarning also triggers on primary key columns, which cannot be nullable anyway.

# Changes

* Guarded the warning such that it is not emitted on primary key columns