### PR TITLE
fix: Conditionally import typing-extensions (#90)

### DIFF
--- a/dataframely/_base_collection.py
+++ b/dataframely/_base_collection.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sys
 import textwrap
 import typing
 from abc import ABCMeta
@@ -11,12 +12,16 @@ from dataclasses import dataclass, field
 from typing import Annotated, Any, cast, get_args, get_origin
 
 import polars as pl
-from typing_extensions import Self
 
 from ._filter import Filter
 from ._typing import LazyFrame as TypedLazyFrame
 from .exc import AnnotationImplementationError, ImplementationError
 from .schema import Schema
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _MEMBER_ATTR = "__dataframely_members__"
 _FILTER_ATTR = "__dataframely_filters__"

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sys
 import textwrap
 from abc import ABCMeta
 from copy import copy
@@ -10,11 +11,15 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import polars as pl
-from typing_extensions import Self
 
 from ._rule import GroupRule, Rule
 from .columns import Column
 from .exc import ImplementationError
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _COLUMN_ATTR = "__dataframely_columns__"
 _RULE_ATTR = "__dataframely_rules__"

--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -3,12 +3,17 @@
 
 from __future__ import annotations
 
+import sys
 from collections import defaultdict
 from collections.abc import Callable
 from typing import Any
 
 import polars as pl
-from typing_extensions import Self
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 ValidationFunction = Callable[[], pl.Expr]
 

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import json
+import sys
 import warnings
 from abc import ABC
 from collections.abc import Mapping, Sequence
@@ -11,7 +12,6 @@ from typing import Annotated, Any, cast
 
 import polars as pl
 import polars.exceptions as plexc
-from typing_extensions import Self
 
 from ._base_collection import BaseCollection, CollectionMember
 from ._filter import Filter
@@ -32,6 +32,11 @@ from .exc import (
 from .failure import FailureInfo
 from .random import Generator
 from .schema import _schema_from_dict
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class Collection(BaseCollection, ABC):

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from abc import ABC, abstractmethod
 from collections import Counter
 from collections.abc import Callable
 from typing import Any, TypeAlias, cast
 
 import polars as pl
-from typing_extensions import Self
 
 from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely._deprecation import (
@@ -19,6 +19,11 @@ from dataframely._deprecation import (
 )
 from dataframely._polars import PolarsDataType
 from dataframely.random import Generator
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 Check: TypeAlias = (
     Callable[[pl.Expr], pl.Expr]

--- a/dataframely/columns/_mixins.py
+++ b/dataframely/columns/_mixins.py
@@ -1,11 +1,11 @@
 # Copyright (c) QuantCo 2025-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
+import sys
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 import polars as pl
-from typing_extensions import Self
 
 if TYPE_CHECKING:  # pragma: no cover
     from ._base import Column
@@ -13,6 +13,11 @@ if TYPE_CHECKING:  # pragma: no cover
     Base = Column
 else:
     Base = object
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 # ----------------------------------- ORDINAL MIXIN ---------------------------------- #
 

--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import math
+import sys
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
 import polars as pl
-from typing_extensions import Self
 
 from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely.random import Generator
@@ -16,6 +16,11 @@ from dataframely.random import Generator
 from ._base import Check, Column
 from ._registry import column_from_dict, register
 from .struct import Struct
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @register

--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
+import sys
 from itertools import chain
 from typing import Any, cast
 
 import polars as pl
-from typing_extensions import Self
 
 from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely._polars import PolarsDataType
@@ -16,6 +16,11 @@ from dataframely.random import Generator
 from ._base import Check, Column
 from ._registry import column_from_dict, register
 from .struct import Struct
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @register

--- a/dataframely/columns/struct.py
+++ b/dataframely/columns/struct.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any, cast
 
 import polars as pl
-from typing_extensions import Self
 
 from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely._polars import PolarsDataType
@@ -14,6 +14,11 @@ from dataframely.random import Generator
 
 from ._base import Check, Column
 from ._registry import column_from_dict, register
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 @register

--- a/dataframely/config.py
+++ b/dataframely/config.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import contextlib
+import sys
 from types import TracebackType
 from typing import TypedDict
 
-from typing_extensions import Unpack
+if sys.version_info > (3, 10):
+    from typing import Unpack
+else:
+    from typing_extensions import Unpack
 
 
 class Options(TypedDict):

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import warnings
 from abc import ABC
 from collections.abc import Iterable, Mapping, Sequence
@@ -14,7 +15,6 @@ import polars as pl
 import polars.exceptions as plexc
 import polars.selectors as cs
 from polars._typing import FileSource, PartitioningScheme
-from typing_extensions import Self
 
 from ._base_schema import BaseSchema
 from ._compat import pa, sa
@@ -33,6 +33,11 @@ from .config import Config
 from .exc import RuleValidationError, ValidationError, ValidationRequiredError
 from .failure import FailureInfo
 from .random import Generator
+
+if sys.version_info > (3, 10):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 _ORIGINAL_NULL_SUFFIX = "__orig_null__"
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -9,17 +9,22 @@
 import datetime
 import decimal
 import functools
+import sys
 from typing import Any, TypedDict
 
 import polars as pl
 import pytest
-from typing_extensions import NotRequired
 
 import dataframely as dy
 
 # Note: To properly test the typing of the library,
 # we also need to make sure that imported schemas are properly processed.
 from dataframely.testing.typing import MyImportedSchema
+
+if sys.version_info > (3, 10):
+    from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
 
 pytestmark = pytest.mark.skip(reason="typing-only tests")
 


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

This PR is to resolve #90. typing-extensions is listed as a dependency when using Python 3.10 or earlier, but is always imported from leading to ImportErrors when using dataframely on newer Python versions.

# Changes

<!-- What changes have been performed? -->

I have changed imports from the typing_extensions module that were added to support Python 3.10 from:

```python
from typing_extensions import X
```

to:

```python
import sys
if sys.version_info > (3, 10):
    from typing import X
else:
    from typing_extensions import X
```

This means that Unpack, NotRequired, and Self are imported from typing when using 3.11 or newer and from typing_extensions otherwise.