### PR TITLE
fix: Properly derive max length of regexes when using alterations

### DIFF
--- a/src/regex_repr.rs
+++ b/src/regex_repr.rs
@@ -60,7 +60,7 @@ fn string_length_recursively(hir: &Hir) -> Result<(usize, Option<usize>)> {
                 .collect::<std::result::Result<Vec<_>, _>>()?;
             (
                 inner.iter().map(|x| x.0).min().unwrap_or(0),
-                inner.iter().map(|x| x.0).max(),
+                inner.iter().flat_map(|x| x.1).max(),
             )
         }
         // A class's length is always a single character and therefore has length 1

--- a/tests/test_extre.py
+++ b/tests/test_extre.py
@@ -21,6 +21,7 @@ import dataframely._extre as extre
         (r"[0-9]{2}[0-9a-zA-Z]{2,4}", 4, 6),
         (r"^[0-9]{2}[0-9a-zA-Z]{2,4}$", 4, 6),
         (r"^[0-9]{2}[0-9a-zA-Z]{2,4}.+$", 5, None),
+        (r"^[A-Z][0-9]{2}(\*|(\.[0-9]{1,2}[*!]?))?$", 3, 7),
     ],
 )
 def test_matching_string_length(


### PR DESCRIPTION
# Motivation

The bug causes SQL schemas to use string lengths that are too short when length is inferred from the regex.

