### PR TITLE
fix: Remove superfluous warning about superfluous collection members

### DIFF
--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -902,14 +902,6 @@ class Collection(BaseCollection, ABC):
                 f"Input misses {len(missing)} required members: {', '.join(missing)}."
             )
 
-        superfluous = actual - set(cls.members())
-        if len(superfluous) > 0:
-            warnings.warn(
-                f"Input provides {len(superfluous)} superfluous members that are "
-                f"ignored: {', '.join(superfluous)}."
-            )
-
-
 def deserialize_collection(data: str) -> type[Collection]:
     """Deserialize a collection from a JSON string.
 

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -902,6 +902,7 @@ class Collection(BaseCollection, ABC):
                 f"Input misses {len(missing)} required members: {', '.join(missing)}."
             )
 
+
 def deserialize_collection(data: str) -> type[Collection]:
     """Deserialize a collection from a JSON string.
 

--- a/tests/collection/test_validate_input.py
+++ b/tests/collection/test_validate_input.py
@@ -19,13 +19,3 @@ class MyCollection(dy.Collection):
 def test_collection_missing_required_member() -> None:
     with pytest.raises(ValueError):
         MyCollection.validate({"second": pl.LazyFrame({"a": [1, 2, 3]})})
-
-
-def test_collection_superfluous_member() -> None:
-    with pytest.warns(Warning):
-        MyCollection.validate(
-            {
-                "first": pl.LazyFrame({"a": [1, 2, 3]}),
-                "third": pl.LazyFrame({"a": [1, 2, 3]}),
-            },
-        )


### PR DESCRIPTION
# Motivation

This warning currently prevents users from easily piping dicts into `Collection.validate` that have extra members. This is often a useful shortcut that allows for elegant and practical code. Additionally, it is hard to imagine when a user would be happy about this warning. Even if it triggers, the user is getting what they ordered: a validated collection with the right members. There is no real opportunity for suprising / undesirable results here.

# Changes

* Removed warning about superfluous columns