### PR TITLE
refactor: Package collection metadata into parquets

### DIFF
--- a/dataframely/_serialization.py
+++ b/dataframely/_serialization.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 import polars as pl
 
 SCHEMA_METADATA_KEY = "dataframely_schema"
+COLLECTION_METADATA_KEY = "dataframely_collection"
 SERIALIZATION_FORMAT_VERSION = "1"
 
 

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -987,7 +987,7 @@ def read_parquet_metadata_collection(
         source: Path to a parquet file or a file-like object that contains the metadata.
 
     Returns:
-        The schema that was serialized to the metadata or ``None`` if no schema metadata
+        The schema that was serialized to the metadata or ``None`` if no collection metadata
         is found.
     """
     metadata = pl.read_parquet_metadata(source)

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -841,8 +841,11 @@ class Collection(BaseCollection, ABC):
                     if scan
                     else pl.read_parquet(source_path, **kwargs).lazy()
                 )
-                parquet_collection_type = read_parquet_metadata_collection(source_path)
-                collection_types.add(parquet_collection_type)
+                if source_path.is_file():
+                    collection_types.add(read_parquet_metadata_collection(source_path))
+                else:
+                    for file in source_path.glob("**/*.parquet"):
+                        collection_types.add(read_parquet_metadata_collection(file))
         return data, _reconcile_collection_types(collection_types)
 
     @classmethod

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -981,7 +981,7 @@ def _extract_keys_if_exist(
 def read_parquet_metadata_collection(
     source: str | Path | IO[bytes] | bytes,
 ) -> type[Collection] | None:
-    """Read a dataframely schema from the metadata of a parquet file.
+    """Read a dataframely Collection type from the metadata of a parquet file.
 
     Args:
         source: Path to a parquet file or a file-like object that contains the metadata.

--- a/tests/collection/test_read_write_parquet.py
+++ b/tests/collection/test_read_write_parquet.py
@@ -29,7 +29,16 @@ def _write_parquet(collection: dy.Collection, path: Path, lazy: bool) -> None:
         collection.sink_parquet(path)
     else:
         collection.write_parquet(path)
-    (path / "schema.json").unlink()
+
+    def _delete_meta(file: Path) -> None:
+        df = pl.read_parquet(file)
+        df.write_parquet(file)
+
+    if path.is_file():
+        _delete_meta(path)
+    else:
+        for file in path.rglob("*.parquet"):
+            _delete_meta(file)
 
 
 def _read_parquet(collection: type[C], path: Path, lazy: bool, **kwargs: Any) -> C:


### PR DESCRIPTION
# Motivation

When serializing collections, we currently rely on creating a `schema.json` file to store the serialized metadata. This approach has the downside that we need to track this extra object, which is structurally different from the parquet files we write. In individual dataframes, we have already unified storage of data and metadata by packaging the metadata into the parquet. This PR uses the same approach to package the metadata of the collection into the members parquet files.

This change is currently not backward compatible. If we decide to go this way, I'd suggest that we add the functionality to fall back to reading `schema.json` files if they exist. I think this should be reasonably straightforward and would establish backward compatibility for reads of previously written files.

# Changes

* Removed the notion `schema.json`.
* Refactored the parquet serialization code to package the metadata information about collections into the parquet metadata.
* When reading back the collection, added checks to ensure that all parquets have the same collection meta data. If they do not, this is treated as if no metadata was found.


