### PR TITLE
fix: Be more lenient when reading metadata

### DIFF
--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -8,6 +8,7 @@ import sys
 import warnings
 from abc import ABC
 from collections.abc import Iterable, Mapping, Sequence
+from json import JSONDecodeError
 from pathlib import Path
 from typing import IO, Any, Literal, overload
 
@@ -970,12 +971,15 @@ def read_parquet_metadata_schema(
         source: Path to a parquet file or a file-like object that contains the metadata.
 
     Returns:
-        The schema that was serialized to the metadata or ``None`` if no schema metadata
-        is found.
+        The schema that was serialized to the metadata. ``None`` if no schema metadata
+        is found or the deserialization fails.
     """
     metadata = pl.read_parquet_metadata(source)
     if (schema_metadata := metadata.get(SCHEMA_METADATA_KEY)) is not None:
-        return deserialize_schema(schema_metadata)
+        try:
+            return deserialize_schema(schema_metadata)
+        except (JSONDecodeError, plexc.ComputeError):
+            return None
     return None
 
 

--- a/tests/collection/test_read_write_parquet.py
+++ b/tests/collection/test_read_write_parquet.py
@@ -11,6 +11,7 @@ import pytest_mock
 from polars.testing import assert_frame_equal
 
 import dataframely as dy
+from dataframely._serialization import COLLECTION_METADATA_KEY
 from dataframely.collection import _reconcile_collection_types
 from dataframely.exc import ValidationRequiredError
 from dataframely.testing import create_collection, create_schema
@@ -375,3 +376,20 @@ def test_reconcile_collection_types(
     inputs: list[type[dy.Collection] | None], output: type[dy.Collection] | None
 ) -> None:
     assert output == _reconcile_collection_types(inputs)
+
+
+# ---------------------------------- MANUAL METADATA --------------------------------- #
+
+
+def test_read_invalid_parquet_metadata_collection(tmp_path: Path) -> None:
+    # Arrange
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    df.write_parquet(
+        tmp_path / "df.parquet", metadata={COLLECTION_METADATA_KEY: "invalid"}
+    )
+
+    # Act
+    collection = dy.read_parquet_metadata_collection(tmp_path / "df.parquet")
+
+    # Assert
+    assert collection is None

--- a/tests/schema/test_read_write_parquet.py
+++ b/tests/schema/test_read_write_parquet.py
@@ -10,6 +10,7 @@ import pytest_mock
 from polars.testing import assert_frame_equal
 
 import dataframely as dy
+from dataframely._serialization import SCHEMA_METADATA_KEY
 from dataframely.exc import ValidationRequiredError
 from dataframely.testing import create_schema
 
@@ -216,3 +217,18 @@ def test_read_write_parquet_validation_skip_invalid_schema(
 
     # Assert
     spy.assert_not_called()
+
+
+# ---------------------------------- MANUAL METADATA --------------------------------- #
+
+
+def test_read_invalid_parquet_metadata_schema(tmp_path: Path) -> None:
+    # Arrange
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    df.write_parquet(tmp_path / "df.parquet", metadata={SCHEMA_METADATA_KEY: "invalid"})
+
+    # Act
+    schema = dy.read_parquet_metadata_schema(tmp_path / "df.parquet")
+
+    # Assert
+    assert schema is None

--- a/tests/test_serializtion.py
+++ b/tests/test_serializtion.py
@@ -1,0 +1,22 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+import json
+
+import polars as pl
+
+from dataframely._serialization import SchemaJSONDecoder
+
+
+def test_decode_json_expression() -> None:
+    # Arrange
+    expr = pl.col("a") + 1
+    encoded = json.dumps(
+        {"__type__": "expression", "value": expr.meta.serialize(format="json")}
+    )
+
+    # Act
+    decoded = json.loads(encoded, cls=SchemaJSONDecoder)
+
+    # Assert
+    assert expr.meta.eq(decoded)


### PR DESCRIPTION
# Motivation

A bump in the polars version can lead to schema metadata being unreadable. Currently, this causes an exception. Instead, we should simply handle this just like when no schema is available.

In addition, this PR unifies the way that expressions and lazy frames are serialized and uses the binary format for both (the JSON format is not available for lazy frames, so, this is the only possible choice if one wants to use the same serialization format for both).