### PR TITLE
fix: Correctly deserialize collections from schema

### DIFF
--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -1010,7 +1010,7 @@ def deserialize_collection(data: str) -> type[Collection]:
         {
             "__annotations__": annotations,
             **{
-                name: Filter(logic=lambda _: logic)
+                name: Filter(logic=lambda _, logic=logic: logic)  # type: ignore
                 for name, logic in decoded["filters"].items()
             },
         },

--- a/tests/collection/test_serialization.py
+++ b/tests/collection/test_serialization.py
@@ -3,6 +3,7 @@
 
 import json
 
+import polars as pl
 import pytest
 
 import dataframely as dy
@@ -57,6 +58,21 @@ class OptionalCollection(dy.Collection):
             },
             {
                 "filter1": Filter(lambda c: c.s1.join(c.s2, on="a")),
+            },
+        ),
+        create_collection(
+            "test",
+            {
+                "s1": create_schema("schema1", {"a": dy.Int64(primary_key=True)}),
+                "s2": create_schema("schema2", {"a": dy.Int64(primary_key=True)}),
+            },
+            {
+                "filter1": Filter(lambda c: c.s1.join(c.s2, on="a")),
+                "filter2": Filter(
+                    lambda c: c.s1.join_where(
+                        c.s2, pl.col("a") + pl.col("a_right") < 10
+                    )
+                ),
             },
         ),
         OptionalCollection,


### PR DESCRIPTION
# Motivation

Deserialization of collection schemas currently yields incorrect results whenever the collection has more than one filter.
