### PR TITLE
fix: Return original dtypes for failures in `filter(..., cast=True)`

### DIFF
--- a/dataframely/_base_collection.py
+++ b/dataframely/_base_collection.py
@@ -137,7 +137,7 @@ class CollectionMeta(ABCMeta):
                     for member in result.members.values()
                 ),
                 *(
-                    set(member.schema._validation_rules())
+                    set(member.schema._validation_rules(with_cast=True))
                     for member in result.members.values()
                 ),
             )

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -17,7 +17,7 @@ import polars.exceptions as plexc
 import polars.selectors as cs
 from polars._typing import FileSource, PartitioningScheme
 
-from ._base_schema import BaseSchema
+from ._base_schema import ORIGINAL_COLUMN_PREFIX, BaseSchema
 from ._compat import pa, sa
 from ._rule import Rule, rule_from_dict, with_evaluation_rules
 from ._serialization import (
@@ -39,8 +39,6 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
-
-_ORIGINAL_NULL_SUFFIX = "__orig_null__"
 
 
 # ------------------------------------------------------------------------------------ #
@@ -360,7 +358,7 @@ class Schema(BaseSchema, ABC):
         combined_dataframe = combined_dataframe.with_columns(override_expressions)
 
         # NOTE: We already know that all columns have the correct dtype
-        rules = cls._validation_rules()
+        rules = cls._validation_rules(with_cast=False)
         filtered, evaluated = cls._filter_raw(combined_dataframe, rules, cast=False)
 
         if evaluated is None:
@@ -476,7 +474,7 @@ class Schema(BaseSchema, ABC):
             # whether casting succeeded.
             # NOTE: This code path is only executed from the `filter` method.
             lf = lf.with_columns(
-                pl.col(cls.column_names()).is_null().name.suffix(_ORIGINAL_NULL_SUFFIX)
+                pl.col(cls.column_names()).name.prefix(ORIGINAL_COLUMN_PREFIX)
             )
 
         lf = validate_dtypes(lf, actual=schema, expected=cls.columns(), casting=casting)
@@ -516,7 +514,7 @@ class Schema(BaseSchema, ABC):
         Note:
             This method preserves the ordering of the input data frame.
         """
-        rules = cls._validation_rules()
+        rules = cls._validation_rules(with_cast=cast)
         df_filtered, df_evaluated = cls._filter_raw(df, rules, cast)
         if df_evaluated is not None:
             failure_lf = (
@@ -524,6 +522,13 @@ class Schema(BaseSchema, ABC):
                 .filter(~pl.col("__final_valid__"))
                 .drop("__final_valid__")
             )
+            if cast:
+                # If we cast, we kept the original values around. In the failure info,
+                # we must return the original values instead of the casted ones.
+                failure_lf = failure_lf.with_columns(
+                    pl.col(f"{ORIGINAL_COLUMN_PREFIX}{name}").alias(name)
+                    for name in cls.column_names()
+                ).drop(f"{ORIGINAL_COLUMN_PREFIX}{name}" for name in cls.column_names())
             return (
                 df_filtered,
                 FailureInfo(lf=failure_lf, rule_columns=list(rules.keys()), schema=cls),
@@ -538,43 +543,14 @@ class Schema(BaseSchema, ABC):
         lf = cls._validate_schema(df.lazy(), casting=("lenient" if cast else "none"))
 
         # Then, we filter the data frame
-        if cast:
-            # Add rules for dtype casting. We can simply check whether the nullability property
-            # of any column value changed due to lenient dtype casting (whenever casting fails,
-            # the value is set to `null` while previous `null` values are simply kept). To this
-            # end, `_validate_schema` kept around the original columns.
-            dtype_rules = {
-                f"{col}|dtype": Rule(
-                    pl.col(col).is_null() == pl.col(f"{col}{_ORIGINAL_NULL_SUFFIX}")
-                )
-                for col in cls.column_names()
-            }
-            rules.update(dtype_rules)
-
         if len(rules) > 0:
-            lf_with_eval = with_evaluation_rules(lf, rules)
-            if cast:
-                # If we cast dtypes, we need to take care of two things:
-                # - There's still a bunch of columns showing the original nullability in the
-                #   data frame. We simply remove these columns again.
-                # - Rules other than the "dtype rule" might not be reliable if type casting
-                #   failed, i.e. if the "dtype rule" evaluated to `False`. For this reason,
-                #   we set all other rule evaluations to `null` in the case of dtype casting
-                #   failure.
-                non_dtype_rule_names = [
-                    rule for rule in rules if not rule.endswith("|dtype")
-                ]
-                all_dtype_casts_valid = pl.all_horizontal(pl.col(r"^.*\|dtype$"))
-                lf_with_eval = lf_with_eval.drop(
-                    cs.matches(f"{_ORIGINAL_NULL_SUFFIX}$")
-                ).with_columns(
-                    pl.when(all_dtype_casts_valid)
-                    .then(pl.col(non_dtype_rule_names))
-                    .otherwise(pl.lit(None, dtype=pl.Boolean))
-                )
+            lf_with_eval = lf.pipe(with_evaluation_rules, rules)
 
             # At this point, `lf_with_eval` contains the following:
-            # - All relevant columns of the original data frame, potentially with cast dtypes
+            # - All relevant columns of the original data frame
+            #   - If `cast` is set to `True`, the columns with their original names are
+            #     already cast and the original values are available in the columns
+            #     prefixed with `ORIGINAL_COLUMN_PREFIX`.
             # - One boolean column for each rule in `rules`
             rule_columns = rules.keys()
             df_evaluated = lf_with_eval.with_columns(
@@ -585,8 +561,12 @@ class Schema(BaseSchema, ABC):
             # and the invalid data frame
             lf = (
                 df_evaluated.lazy()
-                .filter(pl.col("__final_valid__"))
-                .drop("__final_valid__", *rule_columns)
+                .filter("__final_valid__")
+                .drop(
+                    "__final_valid__",
+                    cs.starts_with(ORIGINAL_COLUMN_PREFIX),
+                    *rule_columns,
+                )
             )
         else:
             df_evaluated = None

--- a/dataframely/testing/rules.py
+++ b/dataframely/testing/rules.py
@@ -30,4 +30,4 @@ def evaluate_rules(lf: pl.LazyFrame, rules: dict[str, Rule]) -> pl.LazyFrame:
         The same return value as :meth:`with_evaluation_rules` only that the columns
         of the input data frame are dropped.
     """
-    return with_evaluation_rules(lf, rules).drop(lf.collect_schema().keys())
+    return lf.pipe(with_evaluation_rules, rules).drop(lf.collect_schema().keys())

--- a/tests/column_types/test_array.py
+++ b/tests/column_types/test_array.py
@@ -147,13 +147,7 @@ def test_array_with_rules() -> None:
 def test_outer_nullability() -> None:
     schema = create_schema(
         "test",
-        {
-            "nullable": dy.Array(
-                inner=dy.Integer(),
-                shape=1,
-                nullable=True,
-            )
-        },
+        {"nullable": dy.Array(inner=dy.Integer(), shape=1, nullable=True)},
     )
     df = pl.DataFrame({"nullable": [None, None]})
     schema.validate(df, cast=True)


### PR DESCRIPTION
# Motivation

Fixes #117.
