### PR TITLE
perf: Simplify filter evaluation for collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,6 @@ $RECYCLE.BIN/
 
 # interactive testing
 /*.ipynb
+
+# pytest-benchmark
+.benchmarks/


### PR DESCRIPTION
# Motivation

Initially, this was meant as a necessary refactor for #93. However, the new approach feels more straightforward wrt. code complexity and pytest-benchmark shows a performance improvement of 1.6x-1.7x for `Collection.validate` and `Collection.filter` 🚀 
