### PR TITLE
feat: Allow specifying custom base collection when creating a dynamic collection

### DIFF
--- a/dataframely/testing/factory.py
+++ b/dataframely/testing/factory.py
@@ -36,6 +36,7 @@ def create_collection(
     schemas: dict[str, type[Schema]],
     filters: dict[str, Filter] | None = None,
     *,
+    collection_base_class: type = Collection,
     annotation_base_class: type = LazyFrame,
 ) -> type[Collection]:
     return create_collection_raw(
@@ -45,6 +46,7 @@ def create_collection(
             for name, schema in schemas.items()
         },
         filters=filters,
+        collection_base_class=collection_base_class,
     )
 
 
@@ -52,10 +54,12 @@ def create_collection_raw(
     name: str,
     annotations: dict[str, Any],
     filters: dict[str, Filter] | None = None,
+    *,
+    collection_base_class: type = Collection,
 ) -> type[Collection]:
     return type(
         name,
-        (Collection,),
+        (collection_base_class,),
         {
             "__annotations__": annotations,
             **(filters or {}),

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,0 +1,32 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+import dataframely as dy
+from dataframely.testing import create_collection
+
+
+class MySchema(dy.Schema):
+    a = dy.Integer(primary_key=True)
+
+
+class MyCollection(dy.Collection):
+    member: dy.LazyFrame[MySchema]
+
+    def foo(self) -> str:
+        return "foo"
+
+
+def test_create_collection_base_collection() -> None:
+    # Act
+    temp_collection = create_collection(
+        "TempCollection",
+        {"member": MySchema, "member2": MySchema},
+        collection_base_class=MyCollection,
+    )
+
+    # Assert
+    assert issubclass(temp_collection, MyCollection)
+    instance = temp_collection.sample(10)
+    assert instance.foo() == "foo"
+    assert len(instance.member.collect()) == 10
+    assert len(instance.member2.collect()) == 10  # type: ignore


### PR DESCRIPTION
# Motivation

Currently, all dynamic collections are based directly on `dy.Collection`. It would be nice to allow basing them on a custom collection type so that the dynamic collection inherits whatever additional logic exists there.  

# Changes

- Added base collection as an argument, defaulting to the current behavior. 
