### PR TITLE
refactor: Ensure `filter` and `validate` maintain order

### DIFF
--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -214,10 +214,8 @@ def _with_group_rules(lf: pl.LazyFrame, rules: dict[str, GroupRule]) -> pl.LazyF
         # We group by the group columns and apply all expressions
         group_evaluations[group_columns] = lf.group_by(group_columns).agg(**group_rules)
 
-    # Eventually, we apply the rule evaluations onto the input data frame. For this,
-    # we're using left-joins. This has two effects:
-    #  - We're essentially "broadcasting" the results within each group across rows
-    #    in the same group.
+    # Eventually, we apply the rule evaluations onto the input data frame. For this, we
+    # "broadcast" the results within each group across rows in the same group.
     result = lf
     for group_columns, frame in group_evaluations.items():
         result = result.join(

--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -218,12 +218,10 @@ def _with_group_rules(lf: pl.LazyFrame, rules: dict[str, GroupRule]) -> pl.LazyF
     # we're using left-joins. This has two effects:
     #  - We're essentially "broadcasting" the results within each group across rows
     #    in the same group.
-    #  - While an inner-join would be semantically more accurate, the left-join
-    #    preserves the order of the left data frame.
     result = lf
     for group_columns, frame in group_evaluations.items():
         result = result.join(
-            frame, on=list(group_columns), how="left", nulls_equal=True
+            frame, on=list(group_columns), nulls_equal=True, maintain_order="left"
         )
     return result
 

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -378,7 +378,8 @@ class Collection(BaseCollection, ABC):
         Returns:
             An instance of the collection. All members of the collection are guaranteed
             to be valid with respect to their respective schemas and the filters on this
-            collection did not remove rows from any member.
+            collection did not remove rows from any member. The input order of each
+            member is maintained.
         """
         out, failure = cls.filter(data, cast=cast)
         if any(len(fail) > 0 for fail in failure.values()):
@@ -441,7 +442,9 @@ class Collection(BaseCollection, ABC):
               filtered out by any of the collection's filters. While collection members
               are always instances of :class:`~polars.LazyFrame`, the members of the
               returned collection are essentially eager as they are constructed by
-              calling ``.lazy()`` on eager data frames.
+              calling ``.lazy()`` on eager data frames. Just like in polars' native
+              :meth:`~polars.DataFrame.filter`, the order of rows is maintained in all
+              returned data frames.
             - A mapping from member name to a :class:`FailureInfo` object which provides
               details on why individual rows had been removed. Optional members are only
               included in this dictionary if they had been provided in the input.
@@ -491,6 +494,7 @@ class Collection(BaseCollection, ABC):
                         filter_keep.lazy().with_columns(pl.lit(True).alias(name)),
                         on=primary_keys,
                         how="left",
+                        maintain_order="left",
                     ).with_columns(pl.col(name).fill_null(False))
 
                 result_with_eval = lf_with_eval.collect()

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -416,7 +416,8 @@ class Schema(BaseSchema, ABC):
 
         Returns:
             The (collected) input data frame, wrapped in a generic version of the
-            input's data frame type to reflect schema adherence.
+            input's data frame type to reflect schema adherence. The data frame is
+            guaranteed to maintain its order.
 
         Raises:
             ValidationError: If the input data frame does not satisfy the schema
@@ -504,7 +505,9 @@ class Schema(BaseSchema, ABC):
         Returns:
             A tuple of the validated rows in the input data frame (potentially
             empty) and a simple dataclass carrying information about the rows of the
-            data frame which could not be validated successfully.
+            data frame which could not be validated successfully. Just like in polars'
+            native :meth:`~polars.DataFrame.filter`, the order of rows in the returned
+            data frame is maintained.
 
         Raises:
             ValidationError: If the columns of the input data frame are invalid. This

--- a/tests/collection/test_filter_validate.py
+++ b/tests/collection/test_filter_validate.py
@@ -244,6 +244,13 @@ def test_maintain_order() -> None:
         "first": MyFirstSchema.sample(overrides={"a": range(100_000)}),
         "second": MySecondSchema.sample(overrides={"a": range(200_000)}),
     }
+
+    # Ensure order is maintained in `filter`
     out, _ = MyShufflingCollection.filter(data)
+    assert out.first.select("a").collect().to_series().is_sorted()
+    assert out.second.select("a").collect().to_series().is_sorted()
+
+    # Ensure order is maintained in `validate`
+    out = MyShufflingCollection.validate(out.to_dict())
     assert out.first.select("a").collect().to_series().is_sorted()
     assert out.second.select("a").collect().to_series().is_sorted()


### PR DESCRIPTION
# Motivation

This is easy to support and the guarantee might be helpful for some users. No performance difference can be detected in our benchmark setup.
