### PR TITLE
feat: Add `join` for Collections

### DIFF
--- a/dataframely/_base_collection.py
+++ b/dataframely/_base_collection.py
@@ -66,8 +66,8 @@ class CollectionMember:
 # --------------------------------------- UTILS -------------------------------------- #
 
 
-def _common_primary_keys(columns: Iterable[type[Schema]]) -> set[str]:
-    return set.intersection(*[set(schema.primary_keys()) for schema in columns])
+def _common_primary_keys(schemas: Iterable[type[Schema]]) -> set[str]:
+    return set.intersection(*[set(schema.primary_keys()) for schema in schemas])
 
 
 # ------------------------------------------------------------------------------------ #

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -565,23 +565,32 @@ class Collection(BaseCollection, ABC):
         self,
         primary_keys: pl.LazyFrame,
         how: Literal["semi", "anti"] = "semi",
+        maintain_order: Literal["none", "left"] = "none",
     ) -> Self:
         """Filter the collection by joining onto a data frame containing entries for the
-        common primary key columns whose respective rows should be kept or removed in the
-        collection members.
+        common primary key columns whose respective rows should be kept or removed in
+        the collection members.
 
         Args:
             primary_keys: The data frame to join on. Must contain the common primary key
                 columns of the collection.
             how: The join strategy to use. Like in polars, `semi` will keep all rows
                 that can be found in `primary_keys`, `anti` will remove them.
+            maintain_order: The `maintain_order` option to use for the polars join.
+
+        Returns:
+            The collection, with members potentially reduced in length.
 
         Raises:
             ValueError: If the collection contains any member that is annotated with
                 `ignored_in_filters=True`.
 
-        Returns:
-            The collection, with members potentially reduced in length.
+        Attention:
+            This method does not validate the resulting collection. Ensure to only use
+            this if the resulting collection still satisfies the filters of the collection.
+            The joins are not evaluated eagerly. Therefore, a downstream call to `collect`
+            might fail, especially if `primary_keys` does not contain all columns for all
+            common primary keys.
         """
         if any(member.ignored_in_filters for member in self.members().values()):
             raise ValueError(
@@ -590,7 +599,12 @@ class Collection(BaseCollection, ABC):
 
         return self.cast(
             {
-                key: lf.join(primary_keys, on=self.common_primary_keys(), how=how)
+                key: lf.join(
+                    primary_keys,
+                    on=self.common_primary_keys(),
+                    how=how,
+                    maintain_order=maintain_order,
+                )
                 for key, lf in self.to_dict().items()
             }
         )

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -587,10 +587,10 @@ class Collection(BaseCollection, ABC):
 
         Attention:
             This method does not validate the resulting collection. Ensure to only use
-            this if the resulting collection still satisfies the filters of the collection.
-            The joins are not evaluated eagerly. Therefore, a downstream call to `collect`
-            might fail, especially if `primary_keys` does not contain all columns for all
-            common primary keys.
+            this if the resulting collection still satisfies the filters of the
+            collection. The joins are not evaluated eagerly. Therefore, a downstream
+            call to :meth:`collect` might fail, especially if `primary_keys` does not
+            contain all columns for all common primary keys.
         """
         if any(member.ignored_in_filters for member in self.members().values()):
             raise ValueError(

--- a/dataframely/collection.py
+++ b/dataframely/collection.py
@@ -567,20 +567,18 @@ class Collection(BaseCollection, ABC):
         how: Literal["semi", "anti"] = "semi",
     ) -> Self:
         """Filter the collection by joining onto a data frame containing entries for the
-        common primary keys whose respective rows should be kept or removed in the
+        common primary key columns whose respective rows should be kept or removed in the
         collection members.
 
         Args:
             primary_keys: The data frame to join on. Must contain the common primary key
                 columns of the collection.
             how: The join strategy to use. Like in polars, `semi` will keep all rows
-                that correspond to `primary_keys`, `anti` will remove them.
+                that can be found in `primary_keys`, `anti` will remove them.
 
         Raises:
             ValueError: If the collection contains any member that is annotated with
-                `ignored_in_filters==True`.
-            ColumnNotFoundError: If the `primary_keys` data frame does not contain
-                all common primary key columns of the collection.
+                `ignored_in_filters=True`.
 
         Returns:
             The collection, with members potentially reduced in length.

--- a/tests/collection/test_join.py
+++ b/tests/collection/test_join.py
@@ -1,0 +1,57 @@
+# Copyright (c) QuantCo 2025-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Literal
+
+import polars as pl
+import pytest
+from polars.testing import assert_frame_equal
+
+import dataframely as dy
+
+
+class SchemaOne(dy.Schema):
+    id = dy.Int64(primary_key=True)
+    name = dy.String(nullable=False)
+
+
+class SchemaTwo(dy.Schema):
+    id = dy.Int64(primary_key=True)
+    name = dy.String(nullable=False)
+
+
+class MyCollection(dy.Collection):
+    member_one: dy.LazyFrame[SchemaOne]
+    member_two: dy.LazyFrame[SchemaTwo]
+
+
+@pytest.mark.parametrize("how", ["semi", "anti"])
+def test_join_semi_simple(how: Literal["semi", "anti"]) -> None:
+    # Arrange
+    collection = MyCollection.sample(
+        overrides=[{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}, {"id": 5}]
+    )
+    primary_keys = pl.LazyFrame({"id": [1, 4, 5]})
+
+    # Act
+    result = collection.join(primary_keys, how=how)
+
+    # Assert
+    if how == "semi":
+        assert_frame_equal(
+            result.member_one,
+            collection.member_one.filter(pl.col("id").is_in([1, 4, 5])),
+        )
+        assert_frame_equal(
+            result.member_two,
+            collection.member_two.filter(pl.col("id").is_in([1, 4, 5])),
+        )
+    else:
+        assert_frame_equal(
+            result.member_one,
+            collection.member_one.filter(~pl.col("id").is_in([1, 4, 5])),
+        )
+        assert_frame_equal(
+            result.member_two,
+            collection.member_two.filter(~pl.col("id").is_in([1, 4, 5])),
+        )


### PR DESCRIPTION
# Motivation

When working with collections, it is often helpful to filter all members by the common primary key or remove certain entries this way. 

# Changes

- Added `join` method to `Collection` that allows to semi- or anti-join a collection onto a dataframe containing entries for the common primary key
- Added tests
