### PR TITLE
fix: Correctly handle min and max bounds less than 1 for Decimal (#130)

### DIFF
--- a/tests/column_types/test_decimal.py
+++ b/tests/column_types/test_decimal.py
@@ -37,6 +37,19 @@ def test_args_consistency_min_max(kwargs: dict[str, Any]) -> None:
 @pytest.mark.parametrize(
     "kwargs",
     [
+        {"min": decimal.Decimal(-2), "max": decimal.Decimal(0)},
+        {"min_exclusive": decimal.Decimal(-2), "max": decimal.Decimal(0)},
+        {"min": decimal.Decimal(-2), "max_exclusive": decimal.Decimal(0)},
+        {"min_exclusive": decimal.Decimal(-2), "max_exclusive": decimal.Decimal(0)},
+    ],
+)
+def test_args_zero_and_negative_min_max(kwargs: dict[str, Any]) -> None:
+    dy.Decimal(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
         dict(scale=1, min=decimal.Decimal("3.14")),
         dict(scale=1, min_exclusive=decimal.Decimal("3.14")),
         dict(scale=1, max=decimal.Decimal("3.14")),
@@ -143,11 +156,11 @@ def test_validate_range(
     valid: dict[str, list[bool]],
 ) -> None:
     kwargs = {
-        ("min" if min_inclusive else "min_exclusive"): decimal.Decimal(2),
-        ("max" if max_inclusive else "max_exclusive"): decimal.Decimal(4),
+        ("min" if min_inclusive else "min_exclusive"): decimal.Decimal(0),
+        ("max" if max_inclusive else "max_exclusive"): decimal.Decimal(2),
     }
     column = dy.Decimal(**kwargs)  # type: ignore
-    lf = pl.LazyFrame({"a": [1, 2, 3, 4, 5]})
+    lf = pl.LazyFrame({"a": [-1, 0, 1, 2, 3]})
     actual = evaluate_rules(lf, rules_from_exprs(column.validation_rules(pl.col("a"))))
     expected = pl.LazyFrame(valid)
     assert_frame_equal(actual, expected)


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->

Issue: #130 

`dy.Decimal` currently crashes during validation when instantiated with a min or max value that is 0 or less. This PR changes the way that the number of digits before the decimal place of a `decimal.Decimal` is calculated so that smaller mix/max values can be used as constraints.

# Changes

<!-- What changes have been performed? -->

- The _num_digits helper function used for validating `dy.Decimal` inputs has been changed to use the digits and exponent values from `decimal.Decimal.as_tuple()` to calculate the number of digits instead of using `math.log10`
- Update test cases for `dy.Decimal`
