### PR TITLE
refactor: Store Enum categories as `list` instead of `pl.Series`

### DIFF
--- a/docs/_api/dataframely.columns.rst
+++ b/docs/_api/dataframely.columns.rst
@@ -25,26 +25,10 @@ dataframely.columns.array module
    :show-inheritance:
    :undoc-members:
 
-dataframely.columns.binary module
----------------------------------
-
-.. automodule:: dataframely.columns.binary
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
 dataframely.columns.bool module
 -------------------------------
 
 .. automodule:: dataframely.columns.bool
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-dataframely.columns.categorical module
---------------------------------------
-
-.. automodule:: dataframely.columns.categorical
    :members:
    :show-inheritance:
    :undoc-members:

--- a/docs/_api/dataframely.testing.rst
+++ b/docs/_api/dataframely.testing.rst
@@ -41,14 +41,6 @@ dataframely.testing.rules module
    :show-inheritance:
    :undoc-members:
 
-dataframely.testing.storage module
-----------------------------------
-
-.. automodule:: dataframely.testing.storage
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
 dataframely.testing.typing module
 ---------------------------------
 


### PR DESCRIPTION
# Motivation

We have recently changed our internal representation of enum categories from a `list` to a `pl.Series` (#138), and have regretted it in practice (#141, #147).

This PR should fix most of #147, but that PR also adds tests, so lets rebase it and still merge it after the present PR.

# Changes

* Changed the internal representation of enums to use `list`