### PR TITLE
ci: Make nightly CI work with new polars packaging

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -104,7 +104,7 @@ python = "3.12.*"
 python = "3.13.*"
 
 [feature.nightly.tasks]
-install-polars-nightly = "pip install --pre --no-deps --upgrade --only-binary :all: polars"
+install-polars-nightly = "pip install --pre --no-deps --upgrade --only-binary :all: polars polars-runtime-32"
 
 [environments]
 build = ["build"]


### PR DESCRIPTION
# Motivation

Polars has recently restructured the way their packages work on pypi. As a result, it's not sufficient to install `polars`, which now does not include the rust binaries anymore, but you also need to install `polars-runtime-32` in addition. We could achieve this by either installing it explicitly or removing the `--no-deps` argument to pip. I opted for an explicit install because I like that this makes it very clear what packages we replace here.

# Changes

* Added pip installation of `polars-runtime-32` to setup for nightly CI

# Validation

* [Manual test run](https://github.com/Quantco/dataframely/actions/runs/18373668893) ✅ 