### PR TITLE
feat: Alias `FailureInfo.invalid()` to `.df()`

### DIFF
--- a/dataframely/failure.py
+++ b/dataframely/failure.py
@@ -55,6 +55,13 @@ class FailureInfo(Generic[S]):
         """The rows of the original data frame containing the invalid rows."""
         return self._df.drop(self._rule_columns)
 
+    def df(self) -> pl.DataFrame:
+        """The rows of the original data frame containing the invalid rows.
+
+        Alias for `invalid()`.
+        """
+        return self.invalid()
+
     def counts(self) -> dict[str, int]:
         """The number of validation failures for each individual rule.
 


### PR DESCRIPTION
# Motivation

This feels like the way the API should have been named.

It's common practice to have `df_` or `_df` prefix or suffix in dataframe variables, so it seems a little weird that `failure_info.invalid()` is the nominal way to access the dataframe for failed validation.

I'd go as far as to even suggest just renaming `.invalid()` to `.df()` - not sure if you're open to that suggestion though.

# Changes

Create a method called `FailureInfo.df()` that directly calls `FailureInfo.invalid()`.