### PR TITLE
chore: Fix deprecation warnings in `pixi.toml`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 channels = ["conda-forge"]
 description = "A declarative, polars-native data frame validation library."
 name = "dataframely"
@@ -15,7 +15,6 @@ fsspec = ">=2025.9"
 numpy = "*"
 polars = ">=1.32"
 
-[host-dependencies]
 maturin = ">=1.7,<2"
 pip = "*"
 


### PR DESCRIPTION
# Motivation

See e.g. https://github.com/Quantco/dataframely/actions/runs/18784880084/job/53600418529#step:3:195