### PR TITLE
build: Build for CPython on `osx-64`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         run: pixi run -e build set-version
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Build wheel
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:


### PR DESCRIPTION
# Motivation

I realized that we somehow build for PyPy on `osx-64`.
