### PR TITLE
docs: Fix docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ df = pl.DataFrame({
 validated_df: dy.DataFrame[HouseSchema] = HouseSchema.validate(df, cast=True)
 ```
 
-See more advanced usage examples in the [documentation](https://dataframely.readthedocs.io/en/latest/).
+See more advanced usage examples in the [documentation](https://dataframely.readthedocs.io/stable/).


### PR DESCRIPTION
# Motivation

Docs link in README is broken:
<img width="694" height="235" alt="image" src="https://github.com/user-attachments/assets/28b8b8fc-6299-48a8-906e-9a48fd3995f4" />

# Changes

Fix broken link.
