### PR TITLE
ci: Replace `macos-13` with `macos-15-intel`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           - target-platform: linux-aarch64
             os: ubuntu-24.04-arm
           - target-platform: osx-64
-            os: macos-13
+            os: macos-15-intel
           - target-platform: osx-arm64
             os: macos-latest
           - target-platform: win-64


### PR DESCRIPTION
# Motivation

Brownout period of `macos-13`, see https://github.com/Quantco/dataframely/actions/runs/19081300630/job/54510353369.
