### PR TITLE
feat: Add support for converting `dy.List`, `dy.Array` to postgres array

### DIFF
--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -106,7 +106,7 @@ class Array(Column):
                 )
             case _:
                 raise NotImplementedError(
-                    f"SQL column cannot have 'List' type for dialect '{dialect}'."
+                    f"SQL column cannot have 'Array' type for dialect '{dialect}'."
                 )
 
     def _pyarrow_field_of_shape(self, shape: Sequence[int]) -> pa.Field:

--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -97,15 +97,17 @@ class Array(Column):
         }
 
     def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
-        if dialect.name == "postgresql":
-            # Note that the length of the array in each dimension is not supported in SQLAlchemy
-            # That is because PostgreSQL does not enforce the length anyway
-            return sa.ARRAY(
-                self.inner.sqlalchemy_dtype(dialect), dimensions=len(self.shape)
-            )
-        raise NotImplementedError(
-            f"SQL column cannot have 'Array' type for dialect '{dialect}'."
-        )
+        match dialect.name:
+            case "postgresql":
+                # Note that the length of the array in each dimension is not supported in SQLAlchemy
+                # That is because PostgreSQL does not enforce the length anyway
+                return sa.ARRAY(
+                    self.inner.sqlalchemy_dtype(dialect), dimensions=len(self.shape)
+                )
+            case _:
+                raise NotImplementedError(
+                    f"SQL column cannot have 'List' type for dialect '{dialect}'."
+                )
 
     def _pyarrow_field_of_shape(self, shape: Sequence[int]) -> pa.Field:
         if shape:

--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2025-2025
+# Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from typing import Any, Literal, cast
 
 import polars as pl
 
-from dataframely._compat import PGDialect_psycopg2, pa, sa, sa_TypeEngine
+from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely.random import Generator
 
 from ._base import Check, Column
@@ -97,7 +97,7 @@ class Array(Column):
         }
 
     def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
-        if isinstance(dialect, PGDialect_psycopg2):
+        if dialect.name == "postgresql":
             # Note that the length of the array in each dimension is not supported in SQLAlchemy
             # That is because PostgreSQL does not enforce the length anyway
             return sa.ARRAY(

--- a/dataframely/columns/binary.py
+++ b/dataframely/columns/binary.py
@@ -21,9 +21,11 @@ class Binary(Column):
         return pl.Binary()
 
     def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
-        if dialect.name == "mssql":
-            return sa.VARBINARY()
-        return sa.LargeBinary()
+        match dialect.name:
+            case "mssql":
+                return sa.VARBINARY()
+            case _:
+                return sa.LargeBinary()
 
     @property
     def pyarrow_dtype(self) -> pa.DataType:

--- a/dataframely/columns/binary.py
+++ b/dataframely/columns/binary.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2025-2025
+# Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations

--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2025-2025
+# Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ import polars as pl
 from polars.expr.array import ExprArrayNameSpace
 from polars.expr.list import ExprListNameSpace
 
-from dataframely._compat import PGDialect_psycopg2, pa, sa, sa_TypeEngine
+from dataframely._compat import pa, sa, sa_TypeEngine
 from dataframely._polars import PolarsDataType
 from dataframely.random import Generator
 
@@ -120,7 +120,7 @@ class List(Column):
         }
 
     def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
-        if isinstance(dialect, PGDialect_psycopg2):
+        if dialect.name == "postgresql":
             return sa.ARRAY(self.inner.sqlalchemy_dtype(dialect))
         raise NotImplementedError(
             f"SQL column cannot have 'List' type for dialect '{dialect}'."

--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -11,7 +11,7 @@ import polars as pl
 from polars.expr.array import ExprArrayNameSpace
 from polars.expr.list import ExprListNameSpace
 
-from dataframely._compat import pa, sa, sa_TypeEngine
+from dataframely._compat import PGDialect_psycopg2, pa, sa, sa_TypeEngine
 from dataframely._polars import PolarsDataType
 from dataframely.random import Generator
 
@@ -120,8 +120,11 @@ class List(Column):
         }
 
     def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
-        # NOTE: We might want to add support for PostgreSQL's ARRAY type or use JSON in the future.
-        raise NotImplementedError("SQL column cannot have 'List' type.")
+        if isinstance(dialect, PGDialect_psycopg2):
+            return sa.ARRAY(self.inner.sqlalchemy_dtype(dialect))
+        raise NotImplementedError(
+            f"SQL column cannot have 'List' type for dialect '{dialect}'."
+        )
 
     @property
     def pyarrow_dtype(self) -> pa.DataType:

--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -120,11 +120,13 @@ class List(Column):
         }
 
     def sqlalchemy_dtype(self, dialect: sa.Dialect) -> sa_TypeEngine:
-        if dialect.name == "postgresql":
-            return sa.ARRAY(self.inner.sqlalchemy_dtype(dialect))
-        raise NotImplementedError(
-            f"SQL column cannot have 'List' type for dialect '{dialect}'."
-        )
+        match dialect.name:
+            case "postgresql":
+                return sa.ARRAY(self.inner.sqlalchemy_dtype(dialect))
+            case _:
+                raise NotImplementedError(
+                    f"SQL column cannot have 'List' type for dialect '{dialect}'."
+                )
 
     @property
     def pyarrow_dtype(self) -> pa.DataType:

--- a/tests/columns/test_sqlalchemy_columns.py
+++ b/tests/columns/test_sqlalchemy_columns.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2025-2025
+# Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
@@ -95,6 +95,10 @@ def test_mssql_datatype(column: Column, datatype: str) -> None:
         (dy.String(regex="^[abc]{1,3}d$"), "VARCHAR(4)"),
         (dy.Enum(["foo", "bar"]), "CHAR(3)"),
         (dy.Enum(["a", "abc"]), "VARCHAR(3)"),
+        (dy.List(dy.Integer()), "INTEGER[]"),
+        (dy.List(dy.String(max_length=5)), "VARCHAR(5)[]"),
+        (dy.Array(dy.Integer(), shape=5), "INTEGER[]"),
+        (dy.Array(dy.String(max_length=5), shape=(2, 1)), "VARCHAR(5)[][]"),
     ],
 )
 def test_postgres_datatype(column: Column, datatype: str) -> None:
@@ -136,7 +140,7 @@ def test_sql_multiple_columns(dialect: Dialect) -> None:
     assert len(schema.to_sqlalchemy_columns(dialect)) == 2
 
 
-@pytest.mark.parametrize("dialect", [MSDialect_pyodbc(), PGDialect_psycopg2()])
+@pytest.mark.parametrize("dialect", [MSDialect_pyodbc()])
 def test_raise_for_list_column(dialect: Dialect) -> None:
     with pytest.raises(
         NotImplementedError, match="SQL column cannot have 'List' type."
@@ -144,7 +148,7 @@ def test_raise_for_list_column(dialect: Dialect) -> None:
         dy.List(dy.String()).sqlalchemy_dtype(dialect)
 
 
-@pytest.mark.parametrize("dialect", [MSDialect_pyodbc(), PGDialect_psycopg2()])
+@pytest.mark.parametrize("dialect", [MSDialect_pyodbc()])
 def test_raise_for_array_column(dialect: Dialect) -> None:
     with pytest.raises(
         NotImplementedError, match="SQL column cannot have 'Array' type."


### PR DESCRIPTION
# Motivation

I would like to save lists in postgres.

# Changes

* Added conversion of the `dy.List` and `dy.Array` columns to sqlalchemy array dtypes for postgres.

In the future, we might extend this inference to also support JSONB. I think this would require allowing the user to choose because it appears to me that array is just a sane default here.