### PR TITLE
feat: Allow int values for Decimal type constraints

### DIFF
--- a/dataframely/columns/decimal.py
+++ b/dataframely/columns/decimal.py
@@ -29,10 +29,10 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
-        min: decimal.Decimal | None = None,
-        min_exclusive: decimal.Decimal | None = None,
-        max: decimal.Decimal | None = None,
-        max_exclusive: decimal.Decimal | None = None,
+        min: decimal.Decimal | int | None = None,
+        min_exclusive: decimal.Decimal | int | None = None,
+        max: decimal.Decimal | int | None = None,
+        max_exclusive: decimal.Decimal | int | None = None,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -70,6 +70,15 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
         """
+        if isinstance(min, int):
+            min = decimal.Decimal(min)
+        if isinstance(min_exclusive, int):
+            min_exclusive = decimal.Decimal(min_exclusive)
+        if isinstance(max, int):
+            max = decimal.Decimal(max)
+        if isinstance(max_exclusive, int):
+            max_exclusive = decimal.Decimal(max_exclusive)
+
         if min is not None:
             _validate(min, precision, scale, "min")
         if min_exclusive is not None:

--- a/tests/column_types/test_decimal.py
+++ b/tests/column_types/test_decimal.py
@@ -50,6 +50,21 @@ def test_args_zero_and_negative_min_max(kwargs: dict[str, Any]) -> None:
 @pytest.mark.parametrize(
     "kwargs",
     [
+        {"min": 0},
+        {"min_exclusive": 0},
+        {"max": 0},
+        {"max_exclusive": 0},
+        {"min": -2, "max": 0},
+        {"min_exclusive": -2, "max_exclusive": 0},
+    ],
+)
+def test_int_args_for_min_max(kwargs: dict[str, Any]) -> None:
+    dy.Decimal(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
         dict(scale=1, min=decimal.Decimal("3.14")),
         dict(scale=1, min_exclusive=decimal.Decimal("3.14")),
         dict(scale=1, max=decimal.Decimal("3.14")),

--- a/tests/column_types/test_decimal.py
+++ b/tests/column_types/test_decimal.py
@@ -62,6 +62,19 @@ def test_int_args_for_min_max(kwargs: dict[str, Any]) -> None:
     dy.Decimal(**kwargs)
 
 
+def test_validate_int_args_for_min_max() -> None:
+    column = dy.Decimal(min=0, max_exclusive=3, nullable=True)
+    lf = pl.LazyFrame({"a": [-1, 0, 1, 2, 3]})
+    actual = evaluate_rules(lf, rules_from_exprs(column.validation_rules(pl.col("a"))))
+    expected = pl.LazyFrame(
+        {
+            "min": [False, True, True, True, True],
+            "max_exclusive": [True, True, True, True, False],
+        }
+    )
+    assert_frame_equal(actual, expected)
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [


### PR DESCRIPTION
# Motivation

<!-- Why is this change necessary? Link issues here if applicable. -->
Being able to use `int`s directly in constraint definitions is a bit more ergonomic, and doesn't have any drawbacks as far as I see. 

# Changes

<!-- What changes have been performed? -->
Changed the constraint definitions of `Decimal` to accept `int` values.
