### PR TITLE
fix: Use correct file protocol prefixing

### DIFF
--- a/dataframely/_storage/__init__.py
+++ b/dataframely/_storage/__init__.py
@@ -4,7 +4,4 @@
 from ._base import StorageBackend
 from ._fsspec import get_file_prefix
 
-__all__ = [
-    "StorageBackend",
-    "get_file_prefix"
-]
+__all__ = ["StorageBackend", "get_file_prefix"]

--- a/dataframely/_storage/_fsspec.py
+++ b/dataframely/_storage/_fsspec.py
@@ -1,4 +1,8 @@
+# Copyright (c) QuantCo 2025-2026
+# SPDX-License-Identifier: BSD-3-Clause
+
 from fsspec import AbstractFileSystem
+
 
 def get_file_prefix(fs: AbstractFileSystem) -> str:
     match fs.protocol:

--- a/dataframely/_storage/parquet.py
+++ b/dataframely/_storage/parquet.py
@@ -4,9 +4,10 @@
 from collections.abc import Iterable
 from typing import Any
 
-from dataframely._storage import get_file_prefix
 import polars as pl
 from fsspec import AbstractFileSystem, url_to_fs
+
+from dataframely._storage import get_file_prefix
 
 from ._base import (
     SerializedCollection,

--- a/dataframely/testing/storage.py
+++ b/dataframely/testing/storage.py
@@ -4,13 +4,13 @@
 from abc import ABC, abstractmethod
 from typing import Any, Literal, TypeVar, overload
 
-from dataframely._storage import get_file_prefix
 import polars as pl
 from fsspec import AbstractFileSystem, url_to_fs
 
 import dataframely as dy
 from dataframely import FailureInfo, Validation
 from dataframely._compat import deltalake
+from dataframely._storage import get_file_prefix
 from dataframely._storage.delta import _to_delta_table
 
 # ----------------------------------- Schema -------------------------------------------


### PR DESCRIPTION
# Motivation

The way we treated protocol prefixes was causing problems on windows

# Changes

* Unified and corrected prefix generation 