### PR TITLE
fix: Allow overriding column definitions in schema inheritance

### DIFF
--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -119,24 +119,8 @@ class SchemaMeta(ABCMeta):
         result = Metadata()
         for base in bases:
             result.update(mcs._get_metadata_recursively(base))
-        # Before merging the child namespace, remove any parent columns that the
-        # child explicitly overrides (same attribute name). This allows subclasses to
-        # redefine inherited columns while still detecting genuine alias conflicts.
         namespace_metadata = mcs._get_metadata(namespace)
-        for attr, value in namespace.items():
-            if not isinstance(value, Column):
-                continue
-            # Walk all parent MROs to find if this attribute was a Column in any
-            # parent class. In multiple-inheritance scenarios, the same attribute
-            # name may appear in more than one base with different aliases.
-            keys_to_remove: set[str] = set()
-            for base in bases:
-                for parent_cls in base.__mro__:
-                    parent_col = parent_cls.__dict__.get(attr)
-                    if parent_col is not None and isinstance(parent_col, Column):
-                        keys_to_remove.add(parent_col.alias or attr)
-            for parent_key in keys_to_remove:
-                result.columns.pop(parent_key, None)
+        mcs._remove_overridden_columns(result, namespace, bases)
         result.update(namespace_metadata)
         namespace[_COLUMN_ATTR] = result.columns
         cls = super().__new__(mcs, name, bases, namespace, *args, **kwargs)
@@ -224,6 +208,34 @@ class SchemaMeta(ABCMeta):
             if isinstance(val, Column):
                 val._name = val.alias or name
             return val
+
+    @staticmethod
+    def _remove_overridden_columns(
+        result: Metadata,
+        namespace: dict[str, Any],
+        bases: tuple[type[object], ...],
+    ) -> None:
+        """Remove inherited columns that the child namespace explicitly overrides.
+
+        Before merging the child namespace, we must drop any parent columns whose
+        attribute name is redefined in the child. This allows subclasses to redefine
+        inherited columns while still detecting genuine alias conflicts.
+
+        In multiple-inheritance scenarios, the same attribute name may appear in more
+        than one base with different aliases, so we walk all parent MROs and collect
+        every matching column key to remove.
+        """
+        for attr, value in namespace.items():
+            if not isinstance(value, Column):
+                continue
+            keys_to_remove: set[str] = set()
+            for base in bases:
+                for parent_cls in base.__mro__:
+                    parent_col = parent_cls.__dict__.get(attr)
+                    if parent_col is not None and isinstance(parent_col, Column):
+                        keys_to_remove.add(parent_col.alias or attr)
+            for parent_key in keys_to_remove:
+                result.columns.pop(parent_key, None)
 
     @staticmethod
     def _get_metadata_recursively(kls: type[object]) -> Metadata:

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -126,17 +126,17 @@ class SchemaMeta(ABCMeta):
         for attr, value in namespace.items():
             if not isinstance(value, Column):
                 continue
-            # Walk parent MRO to find if this attribute was a Column in a parent class.
+            # Walk all parent MROs to find if this attribute was a Column in any
+            # parent class. In multiple-inheritance scenarios, the same attribute
+            # name may appear in more than one base with different aliases.
+            keys_to_remove: set[str] = set()
             for base in bases:
                 for parent_cls in base.__mro__:
                     parent_col = parent_cls.__dict__.get(attr)
                     if parent_col is not None and isinstance(parent_col, Column):
-                        parent_key = parent_col.alias or attr
-                        result.columns.pop(parent_key, None)
-                        break
-                else:
-                    continue
-                break
+                        keys_to_remove.add(parent_col.alias or attr)
+            for parent_key in keys_to_remove:
+                result.columns.pop(parent_key, None)
         result.update(namespace_metadata)
         namespace[_COLUMN_ATTR] = result.columns
         cls = super().__new__(mcs, name, bases, namespace, *args, **kwargs)

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -119,7 +119,25 @@ class SchemaMeta(ABCMeta):
         result = Metadata()
         for base in bases:
             result.update(mcs._get_metadata_recursively(base))
-        result.update(mcs._get_metadata(namespace))
+        # Before merging the child namespace, remove any parent columns that the
+        # child explicitly overrides (same attribute name). This allows subclasses to
+        # redefine inherited columns while still detecting genuine alias conflicts.
+        namespace_metadata = mcs._get_metadata(namespace)
+        for attr, value in namespace.items():
+            if not isinstance(value, Column):
+                continue
+            # Walk parent MRO to find if this attribute was a Column in a parent class.
+            for base in bases:
+                for parent_cls in base.__mro__:
+                    parent_col = parent_cls.__dict__.get(attr)
+                    if parent_col is not None and isinstance(parent_col, Column):
+                        parent_key = parent_col.alias or attr
+                        result.columns.pop(parent_key, None)
+                        break
+                else:
+                    continue
+                break
+        result.update(namespace_metadata)
         namespace[_COLUMN_ATTR] = result.columns
         cls = super().__new__(mcs, name, bases, namespace, *args, **kwargs)
 

--- a/tests/schema/test_base.py
+++ b/tests/schema/test_base.py
@@ -141,3 +141,11 @@ def test_user_error_polars_datatype_type() -> None:
         class MySchemaWithPolarsDataTypeType(dy.Schema):
             a = dy.Int32(nullable=False)
             b = pl.String  # User error: Used pl.String instead of dy.String()
+
+
+def test_override() -> None:
+    class FirstSchema(dy.Schema):
+        x = dy.Int64()
+
+    class SecondSchema(FirstSchema):
+        x = dy.Int64(nullable=True)

--- a/tests/schema/test_base.py
+++ b/tests/schema/test_base.py
@@ -149,3 +149,14 @@ def test_override() -> None:
 
     class SecondSchema(FirstSchema):
         x = dy.Int64(nullable=True)
+
+    first_columns = FirstSchema.columns()
+    second_columns = SecondSchema.columns()
+
+    assert set(first_columns) == {"x"}
+    assert set(second_columns) == {"x"}
+
+    assert first_columns["x"].nullable is False
+    assert second_columns["x"].nullable is True
+
+    assert type(second_columns["x"]) is type(first_columns["x"])


### PR DESCRIPTION
# Motivation

PR #291 introduced duplicate alias detection, but it also broke overriding column definitions in subclasses. For example, this valid pattern started raising an error:

```python
class FirstSchema(dy.Schema):
    x = dy.Int64()

class SecondSchema(FirstSchema):
    x = dy.Int64(nullable=True)  # Override — should be allowed
```

# Changes

Before merging the child namespace into the inherited metadata, walk the parent MRO to identify columns that share the same attribute name as a child-defined column. Remove those parent columns so the child's definition takes precedence, while still detecting genuine alias conflicts (e.g., a new column `b` with an alias that clashes with an inherited column `a`).

# Validation

- `test_override` — new test that verifies subclass column overrides work
- `test_duplicate_alias_same_schema` and `test_duplicate_alias_inherited_schema` — existing tests still pass, confirming alias conflict detection is preserved