### PR TITLE
build: Ensure that Linux builds use Python 3.10 ABI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,14 +57,11 @@ jobs:
           environments: build
       - name: Set version
         run: pixi run -e build set-version
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.10"
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:
           command: build
-          args: --out dist --release
+          args: --out dist --release -i python3.10
           manylinux: auto
           sccache: true
       - name: Check package


### PR DESCRIPTION
## Summary

- Fix Linux wheels being built as `cp38-cp38` instead of `cp310-abi3`
- Pass `-i python3.10` to maturin for Linux builds to ensure abi3 wheels are produced
- This allows Linux users to install without requiring Rust on the target system

## Root Cause

The `actions/setup-python` action sets up Python 3.10 on the host runner, but this has no effect inside the manylinux Docker container used for Linux builds. The manylinux2014 container's default Python is 3.8, causing maturin to build non-abi3 wheels.

From the [maturin-action README](https://github.com/PyO3/maturin-action#manylinux-docker-container):
> Note that the `actions/setup-python` action won't affect manylinux build since it's containerized, so if you want to build for certain Python version for Linux, use `-i pythonX.Y` in the `args` option

## Test plan

- [ ] CI builds pass
- [ ] Verify Linux wheel artifacts are named `cp310-abi3-manylinux*` instead of `cp38-cp38-manylinux*`

Fixes #303

---
This PR was created with assistance from Claude Code (AI).

🤖 Generated with [Claude Code](https://claude.ai/code)