### PR TITLE
fix: Ignore `dy.Any` columns in `Schema.cast`

### DIFF
--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -813,7 +813,6 @@ class Schema(BaseSchema, ABC):
             the lazy frame's schema but also means that a call to :meth:`polars.LazyFrame.collect`
             further down the line might fail because of the cast and/or missing columns.
         """
-
         lf = match_to_schema(df.lazy(), cls, casting="strict")
         if isinstance(df, pl.DataFrame):
             return lf.collect()  # type: ignore

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -38,6 +38,7 @@ from ._storage.parquet import (
     ParquetStorageBackend,
 )
 from ._typing import DataFrame, LazyFrame, Validation
+from .columns import Any as AnyColumn
 from .columns import Column, column_from_dict
 from .config import Config
 from .exc import (
@@ -814,7 +815,9 @@ class Schema(BaseSchema, ABC):
             further down the line might fail because of the cast and/or missing columns.
         """
         lf = df.lazy().select(
-            pl.col(name).cast(col.dtype) for name, col in cls.columns().items()
+            # Skip casting for Any columns since they accept any type
+            pl.col(name) if isinstance(col, AnyColumn) else pl.col(name).cast(col.dtype)
+            for name, col in cls.columns().items()
         )
         if isinstance(df, pl.DataFrame):
             return lf.collect()  # type: ignore

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -38,7 +38,6 @@ from ._storage.parquet import (
     ParquetStorageBackend,
 )
 from ._typing import DataFrame, LazyFrame, Validation
-from .columns import Any as AnyColumn
 from .columns import Column, column_from_dict
 from .config import Config
 from .exc import (
@@ -814,11 +813,19 @@ class Schema(BaseSchema, ABC):
             the lazy frame's schema but also means that a call to :meth:`polars.LazyFrame.collect`
             further down the line might fail because of the cast and/or missing columns.
         """
-        lf = df.lazy().select(
-            # Skip casting for Any columns since they accept any type
-            pl.col(name) if isinstance(col, AnyColumn) else pl.col(name).cast(col.dtype)
-            for name, col in cls.columns().items()
-        )
+
+        def _cast_to_schema(
+            lf: pl.LazyFrame, schema: dict[str, pl.DataType]
+        ) -> pl.LazyFrame:
+            return lf.select(cls.column_names()).cast(
+                {
+                    name: col.dtype
+                    for name, col in cls.columns().items()
+                    if name in schema and not col.validate_dtype(schema[name])
+                }
+            )
+
+        lf = df.lazy().pipe_with_schema(_cast_to_schema)
         if isinstance(df, pl.DataFrame):
             return lf.collect()  # type: ignore
         return lf  # type: ignore

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -816,13 +816,14 @@ class Schema(BaseSchema, ABC):
 
         def _cast_to_schema(
             lf: pl.LazyFrame, schema: dict[str, pl.DataType]
-        # NOTE: This function does almost the same thing as `match_to_schema`, except:
-        #
-        # 1. It raises a polars `polars.exceptionsColumnNotFoundError` on missing columns, 
-        #    while `match_to_schema` raises a `dataframely.exc.SchemaError`
-        # 2. The error is raised only at collection time, while `match_to_schema` raises immediately
-        #
-        # This behavior is needed to not break backward compatibility.
+        ) -> pl.LazyFrame:
+            # NOTE: This function does almost the same thing as `match_to_schema`, except:
+            #
+            # 1. It raises a polars `polars.exceptionsColumnNotFoundError` on missing columns,
+            #    while `match_to_schema` raises a `dataframely.exc.SchemaError`
+            # 2. The error is raised only at collection time, while `match_to_schema` raises immediately
+            #
+            # This behavior is needed to not break backward compatibility.
             return lf.select(cls.column_names()).cast(
                 {
                     name: col.dtype

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -814,25 +814,7 @@ class Schema(BaseSchema, ABC):
             further down the line might fail because of the cast and/or missing columns.
         """
 
-        def _cast_to_schema(
-            lf: pl.LazyFrame, schema: dict[str, pl.DataType]
-        ) -> pl.LazyFrame:
-            # NOTE: This function does almost the same thing as `match_to_schema`, except:
-            #
-            # 1. It raises a polars `polars.exceptionsColumnNotFoundError` on missing columns,
-            #    while `match_to_schema` raises a `dataframely.exc.SchemaError`
-            # 2. The error is raised only at collection time, while `match_to_schema` raises immediately
-            #
-            # This behavior is needed to not break backward compatibility.
-            return lf.select(cls.column_names()).cast(
-                {
-                    name: col.dtype
-                    for name, col in cls.columns().items()
-                    if name in schema and not col.validate_dtype(schema[name])
-                }
-            )
-
-        lf = df.lazy().pipe_with_schema(_cast_to_schema)
+        lf = match_to_schema(df.lazy(), cls, casting="strict")
         if isinstance(df, pl.DataFrame):
             return lf.collect()  # type: ignore
         return lf  # type: ignore

--- a/dataframely/schema.py
+++ b/dataframely/schema.py
@@ -816,7 +816,13 @@ class Schema(BaseSchema, ABC):
 
         def _cast_to_schema(
             lf: pl.LazyFrame, schema: dict[str, pl.DataType]
-        ) -> pl.LazyFrame:
+        # NOTE: This function does almost the same thing as `match_to_schema`, except:
+        #
+        # 1. It raises a polars `polars.exceptionsColumnNotFoundError` on missing columns, 
+        #    while `match_to_schema` raises a `dataframely.exc.SchemaError`
+        # 2. The error is raised only at collection time, while `match_to_schema` raises immediately
+        #
+        # This behavior is needed to not break backward compatibility.
             return lf.select(cls.column_names()).cast(
                 {
                     name: col.dtype

--- a/tests/collection/test_cast.py
+++ b/tests/collection/test_cast.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import polars as pl
-import polars.exceptions as plexc
 import pytest
 
 import dataframely as dy
+from dataframely.exc import SchemaError
 
 
 class FirstSchema(dy.Schema):
@@ -48,12 +48,12 @@ def test_cast_invalid_members(df_type: type[pl.DataFrame] | type[pl.LazyFrame]) 
 
 def test_cast_invalid_member_schema_eager() -> None:
     first = pl.DataFrame({"b": [3]})
-    with pytest.raises(plexc.ColumnNotFoundError):
+    with pytest.raises(SchemaError):
         Collection.cast({"first": first})
 
 
 def test_cast_invalid_member_schema_lazy() -> None:
     first = pl.LazyFrame({"b": [3]})
     collection = Collection.cast({"first": first})
-    with pytest.raises(plexc.ColumnNotFoundError):
+    with pytest.raises(SchemaError):
         collection.collect_all()

--- a/tests/column_types/test_any.py
+++ b/tests/column_types/test_any.py
@@ -20,3 +20,9 @@ class AnySchema(dy.Schema):
 def test_any_dtype_passes(data: dict[str, Any]) -> None:
     df = pl.DataFrame(data)
     assert AnySchema.is_valid(df)
+
+
+def test_any_cast() -> None:
+    df = pl.DataFrame({"a": 0})
+    result = AnySchema.cast(df)
+    assert result["a"].dtype == pl.Int64

--- a/tests/schema/test_cast.py
+++ b/tests/schema/test_cast.py
@@ -1,13 +1,12 @@
 # Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
-
 from typing import Any
 
 import polars as pl
-import polars.exceptions as plexc
 import pytest
 
 import dataframely as dy
+from dataframely.exc import SchemaError
 
 
 class MySchema(dy.Schema):
@@ -34,14 +33,14 @@ def test_cast_valid(
 
 def test_cast_invalid_schema_eager() -> None:
     df = pl.DataFrame({"a": [1]})
-    with pytest.raises(plexc.ColumnNotFoundError):
+    with pytest.raises(SchemaError):
         MySchema.cast(df)
 
 
 def test_cast_invalid_schema_lazy() -> None:
     lf = pl.LazyFrame({"a": [1]})
     lf = MySchema.cast(lf)
-    with pytest.raises(plexc.ColumnNotFoundError):
+    with pytest.raises(SchemaError):
         lf.collect()
 
 

--- a/tests/schema/test_cast.py
+++ b/tests/schema/test_cast.py
@@ -43,3 +43,18 @@ def test_cast_invalid_schema_lazy() -> None:
     lf = MySchema.cast(lf)
     with pytest.raises(plexc.ColumnNotFoundError):
         lf.collect()
+
+
+class IntegerSchema(dy.Schema):
+    a = dy.Integer()
+
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+def test_cast_preserves_valid_dtype(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame],
+) -> None:
+    """Test that cast doesn't change already valid dtypes (issue #318)."""
+    df = df_type({"a": [1, 2, 3]}, schema={"a": pl.Int32})
+    result = IntegerSchema.cast(df)
+    # Int32 is valid for dy.Integer, so it should NOT be cast to Int64
+    assert result.lazy().collect_schema()["a"] == pl.Int32


### PR DESCRIPTION
# Motivation

Fixes: #314 

# Changes

`Schema.cast` ignores the `dy.Any` columns.


