### PR TITLE
feat(columns): Add methods to transform existing column definitions

### DIFF
--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -235,20 +235,18 @@ class Column(ABC):
         return pl.col(self.name)
 
     def with_properties(self, **kwargs: Any) -> Self:
-        """Return a new column definition with updated public properties.
+        """Copy the current column definition while updating the provided properties.
 
-        Creates a copy of this column with the specified properties updated.
         All other properties from the original column are preserved.
 
         Args:
-            **kwargs: Properties to update on the new column instance.
-
+            **kwargs: Properties to update on the new column instance. The set of allowed properties depends on the type of the column.
         Returns:
             A new column instance with updated properties.
         """
         new_kwargs = {
-            k: v for k, v in self.__dict__.items() if not k.startswith("_")
-        } | kwargs  # keep private attributes private
+            k: getattr(self, k) for k in inspect.signature(self.__class__).parameters
+        } | kwargs
         return self.__class__(**new_kwargs)
 
     def with_nullable(self, nullable: bool) -> Self:

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -241,6 +241,7 @@ class Column(ABC):
 
         Args:
             **kwargs: Properties to update on the new column instance. The set of allowed properties depends on the type of the column.
+
         Returns:
             A new column instance with updated properties.
         """

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -234,6 +234,78 @@ class Column(ABC):
         """Obtain a Polars column expression for the column."""
         return pl.col(self.name)
 
+    def with_properties(self, **kwargs: Any) -> Self:
+        """Return a new column definition with updated public properties.
+
+        Creates a copy of this column with the specified properties updated.
+        All other properties from the original column are preserved.
+
+        Args:
+            **kwargs: Properties to update on the new column instance.
+
+        Returns:
+            A new column instance with updated properties.
+        """
+        new_kwargs = {
+            k: v for k, v in self.__dict__.items() if not k.startswith("_")
+        } | kwargs  # keep private attributes private
+        return self.__class__(**new_kwargs)
+
+    def with_nullable(self, nullable: bool) -> Self:
+        """Return a new column definition with specified nullability.
+
+        Args:
+            nullable: Whether the new column may contain null values.
+
+        Returns:
+            A new column instance with updated nullability.
+        """
+        return self.with_properties(nullable=nullable)
+
+    def with_alias(self, alias: str) -> Self:
+        """Return a new column definition with a specified alias.
+
+        Args:
+            alias: The alias to use for the column name.
+
+        Returns:
+            A new column instance with the specified alias.
+        """
+        return self.with_properties(alias=alias)
+
+    def with_check(self, check: Check) -> Self:
+        """Return a new column definition with a specified check.
+
+        Args:
+            check: A custom validation rule or rules for the column.
+
+        Returns:
+            A new column instance with the specified check.
+        """
+        return self.with_properties(check=check)
+
+    def with_primary_key(self, primary_key: bool) -> Self:
+        """Return a new column definition with a specified primary key status.
+
+        Args:
+            primary_key: Whether the column should be part of the primary key.
+
+        Returns:
+            A new column instance with updated primary key status.
+        """
+        return self.with_properties(primary_key=primary_key)
+
+    def with_metadata(self, metadata: dict[str, Any]) -> Self:
+        """Return a new column definition with specified metadata.
+
+        Args:
+            metadata: A dictionary of metadata to attach to the column.
+
+        Returns:
+            A new column instance with the specified metadata.
+        """
+        return self.with_properties(metadata=metadata)
+
     # ----------------------------------- SAMPLING ----------------------------------- #
 
     def sample(self, generator: Generator, n: int = 1) -> pl.Series:

--- a/dataframely/columns/any.py
+++ b/dataframely/columns/any.py
@@ -25,18 +25,12 @@ class Any(Column):
     def __init__(
         self,
         *,
-        nullable: bool = True,
-        primary_key: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
-            nullable: Whether this column may contain null values.
-                Always `True` for the Any type.
-            primary_key: Whether this column is part of the primary key of the schema.
-                Always `False` for the Any type.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -54,10 +48,6 @@ class Any(Column):
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
         """
-        if not nullable:
-            raise NotImplementedError("The 'Any' type column must be nullable.")
-        if primary_key:
-            raise NotImplementedError("The 'Any' type column cannot be a primary key.")
         super().__init__(
             nullable=True,
             primary_key=False,

--- a/dataframely/columns/any.py
+++ b/dataframely/columns/any.py
@@ -54,6 +54,10 @@ class Any(Column):
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
         """
+        if not nullable:
+            raise NotImplementedError("The 'Any' type column must be nullable.")
+        if primary_key:
+            raise NotImplementedError("The 'Any' type column cannot be a primary key.")
         super().__init__(
             nullable=True,
             primary_key=False,

--- a/dataframely/columns/any.py
+++ b/dataframely/columns/any.py
@@ -25,12 +25,18 @@ class Any(Column):
     def __init__(
         self,
         *,
+        nullable: bool = True,
+        primary_key: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
     ):
         """
         Args:
+            nullable: Whether this column may contain null values.
+                Always `True` for the Any type.
+            primary_key: Whether this column is part of the primary key of the schema.
+                Always `False` for the Any type.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to

--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -1,12 +1,184 @@
 # Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
+from typing import Any
+
 import pytest
 
 import dataframely as dy
+from dataframely.columns._base import Check
 
 
 @pytest.mark.parametrize("column_type", [dy.Int64, dy.String, dy.Float32, dy.Decimal])
 def test_no_nullable_primary_key(column_type: type[dy.Column]) -> None:
     with pytest.raises(ValueError):
         column_type(primary_key=True, nullable=True)
+
+
+@pytest.mark.parametrize(
+    ["existing_col", "properties"],
+    [
+        (dy.Any(alias="bar"), {"alias": "foo"}),
+        (dy.Array(inner=dy.Any(), shape=2), {"shape": (3,)}),
+        (dy.Date(resolution="1mo"), {"resolution": "1d"}),
+        (dy.Datetime(time_unit="ms"), {"time_unit": "us"}),
+        (dy.Decimal(precision=10, scale=2), {"precision": 12, "scale": 3}),
+        (dy.Duration(time_unit="ms"), {"time_unit": "us"}),
+        (dy.Enum(categories=["foo", "bar"]), {"categories": ["foo", "bar", "baz"]}),
+        (dy.Float(allow_inf=False), {"allow_inf": True}),
+        (dy.Float32(allow_nan=False), {"allow_nan": True}),
+        (dy.Float64(min=0.0), {"min": 1.0}),
+        (dy.Int8(max=100), {"max": 127}),
+        (dy.Int16(min=-100), {"min": -200}),
+        (dy.Int32(is_in=[1, 2, 3]), {"is_in": [1, 2, 3, 4]}),
+        (dy.Int64(min=1), {"min": 0}),
+        (dy.Integer(max=100), {"max": 200}),
+        (dy.List(inner=dy.Any(), min_length=1), {"min_length": 2}),
+        (dy.String(regex=r".*"), {"regex": r".+"}),
+        (
+            dy.Struct(inner={"field": dy.Int64()}, nullable=False),
+            {"inner": {"field": dy.Int64(min=0)}, "nullable": True},
+        ),
+        (dy.Time(resolution="1s"), {"resolution": "1ms"}),
+        (dy.UInt8(max=200), {"max": 255}),
+        (dy.UInt16(min=100), {"min": 50}),
+        (dy.UInt32(min_exclusive=10), {"min_exclusive": 20}),
+        (dy.UInt64(max_exclusive=1000), {"max_exclusive": 2000}),
+    ],
+    ids=[
+        "Any",
+        "Array",
+        "Date",
+        "Datetime",
+        "Decimal",
+        "Duration",
+        "Enum",
+        "Float",
+        "Float32",
+        "Float64",
+        "Int8",
+        "Int16",
+        "Int32",
+        "Int64",
+        "Integer",
+        "List",
+        "String",
+        "Struct",
+        "Time",
+        "UInt8",
+        "UInt16",
+        "UInt32",
+        "UInt64",
+    ],
+)
+def test_with_properties(existing_col: dy.Column, properties: dict[str, Any]) -> None:
+    """It assigns the property to the new column but not the old column."""
+    new_col = existing_col.with_properties(**properties)
+
+    assert all(getattr(new_col, key) == value for key, value in properties.items())
+    assert all(getattr(existing_col, key) != value for key, value in properties.items())
+    assert all(
+        getattr(existing_col, key) == getattr(new_col, key)
+        for key in existing_col.__dict__.keys()
+        if key not in properties
+    )
+
+
+@pytest.mark.parametrize(
+    ["col_type", "col_kwargs"],
+    [
+        (dy.Any, {}),
+        (dy.Array, {"inner": dy.Any(), "shape": 2}),
+        (dy.Binary, {}),
+        (dy.Bool, {}),
+        (dy.Categorical, {}),
+        (dy.Date, {}),
+        (dy.Datetime, {}),
+        (dy.Decimal, {}),
+        (dy.Duration, {}),
+        (dy.Enum, {"categories": ["foo", "bar", "baz"]}),
+        (dy.Float, {}),
+        (dy.Float32, {}),
+        (dy.Float64, {}),
+        (dy.Int8, {}),
+        (dy.Int16, {}),
+        (dy.Int32, {}),
+        (dy.Int64, {}),
+        (dy.Integer, {}),
+        (dy.List, {"inner": dy.Any()}),
+        (dy.Object, {}),
+        (dy.String, {}),
+        (dy.Struct, {"inner": dy.Any()}),
+        (dy.Time, {}),
+        (dy.UInt8, {}),
+        (dy.UInt16, {}),
+        (dy.UInt32, {}),
+        (dy.UInt64, {}),
+    ],
+    ids=[
+        "Any",
+        "Array",
+        "Binary",
+        "Bool",
+        "Categorical",
+        "Date",
+        "Datetime",
+        "Decimal",
+        "Duration",
+        "Enum",
+        "Float",
+        "Float32",
+        "Float64",
+        "Int8",
+        "Int16",
+        "Int32",
+        "Int64",
+        "Integer",
+        "List",
+        "Object",
+        "String",
+        "Struct",
+        "Time",
+        "UInt8",
+        "UInt16",
+        "UInt32",
+        "UInt64",
+    ],
+)
+@pytest.mark.parametrize(
+    ["property", "original_value", "new_value"],
+    [
+        ("alias", "foo", "bar"),
+        ("metadata", {"key": "value"}, {"key": "new_value"}),
+        ("check", lambda x: x.is_not_null().all(), lambda x: x.is_null().all()),
+        ("nullable", True, False),
+        ("primary_key", False, True),
+    ],
+)
+def test_with(
+    col_type: type[dy.Column],
+    col_kwargs: dict[str, Any],
+    property: str,
+    original_value: str | dict[str, Any] | Check | bool,
+    new_value: str,
+) -> None:
+    """It only updates the called property."""
+    # Some column types don't support primary_key
+    if property == "primary_key" and col_type in [dy.Any, dy.Array, dy.List, dy.Object]:
+        pytest.xfail(f"{col_type.__name__} does not support primary_key")
+
+    # Any column type doesn't support changing nullable
+    if property == "nullable" and col_type == dy.Any:
+        pytest.xfail("Any does not support changing nullable")
+
+    col = col_type(**col_kwargs)
+    setattr(col, property, original_value)
+
+    new_col = getattr(col, f"with_{property}")(new_value)
+
+    assert getattr(new_col, property) == new_value
+    assert all(
+        getattr(col, key) == getattr(new_col, key)
+        for key in col.__dict__.keys()
+        if key != property
+    )

--- a/tests/columns/test_base.py
+++ b/tests/columns/test_base.py
@@ -6,7 +6,6 @@ from typing import Any
 import pytest
 
 import dataframely as dy
-from dataframely.columns._base import Check
 
 
 @pytest.mark.parametrize("column_type", [dy.Int64, dy.String, dy.Float32, dy.Decimal])
@@ -72,16 +71,23 @@ def test_no_nullable_primary_key(column_type: type[dy.Column]) -> None:
     ],
 )
 def test_with_properties(existing_col: dy.Column, properties: dict[str, Any]) -> None:
-    """It assigns the property to the new column but not the old column."""
+    original_state = {
+        key: getattr(existing_col, key) for key in existing_col.__dict__.keys()
+    }
+
     new_col = existing_col.with_properties(**properties)
 
-    assert all(getattr(new_col, key) == value for key, value in properties.items())
-    assert all(getattr(existing_col, key) != value for key, value in properties.items())
+    assert existing_col.__dict__ == original_state, "Original column was mutated"
+
+    assert all(getattr(new_col, key) == value for key, value in properties.items()), (
+        "New column did not receive new properties"
+    )
+
     assert all(
         getattr(existing_col, key) == getattr(new_col, key)
         for key in existing_col.__dict__.keys()
         if key not in properties
-    )
+    ), "Property was updated even though it should not have been"
 
 
 @pytest.mark.parametrize(
@@ -159,10 +165,9 @@ def test_with(
     col_type: type[dy.Column],
     col_kwargs: dict[str, Any],
     property: str,
-    original_value: str | dict[str, Any] | Check | bool,
-    new_value: str,
+    original_value: Any,
+    new_value: Any,
 ) -> None:
-    """It only updates the called property."""
     # Some column types don't support primary_key
     if property == "primary_key" and col_type in [dy.Any, dy.Array, dy.List, dy.Object]:
         pytest.xfail(f"{col_type.__name__} does not support primary_key")
@@ -171,8 +176,7 @@ def test_with(
     if property == "nullable" and col_type == dy.Any:
         pytest.xfail("Any does not support changing nullable")
 
-    col = col_type(**col_kwargs)
-    setattr(col, property, original_value)
+    col = col_type(**col_kwargs | {property: original_value})
 
     new_col = getattr(col, f"with_{property}")(new_value)
 


### PR DESCRIPTION
# Motivation

Suppose you have a schema like:
```python
class MySchema(dy.Schema):
    col1 = dy.Struct(inner = {"foo": dy.List(inner = dy.Struct(inner = {"bar": dy.String}))}, alias = "my.reserved.column.alias")
```
and now I want to add a new column that's basically identical, just with a different alias. That's a lot to type again! Plus, if the definitions change together, it's easier for them to grow out of sync. Instead, of redefining this column, I'd like to do this:
```python
class MySchema(dy.Schema):
    col1 = dy.Struct(inner = {"foo": dy.List(inner = dy.Struct(inner = {"bar": dy.String}))}, alias = "my.reserved.column.alias")
    col2 = col1.with_alias("my.other.reserved.alias")
```
Same goes for other common properties like `primary_key`, `nullability`, and `metadata`. At @mbta, we use dataframely as part of our ingestion ETL. We ingest deeply nested JSON and being able to reuse column definitions would be helpful.

# Changes

1. Add a new method `with_properties` that returns a new column with defined properties. For example, `dy.List(inner = dy.Any()).with_properties(inner = dy.String())` would return a list with a `String` inner column. All public properties are settable, though invalid properties (eg. `Any` with `nullable = False` are still disallowed since this implementation works through the constructor.
2. Add wrappers for common properties `with_nullable`, `with_alias`, `with_metadata`, and `with_primary_key`
3. Enable `Any` to accept `nullable` and `primary_key` kwargs. This is consistent with how `Array` works and allows a much cleaner implementation of `with_properties`
