### PR TITLE
feat: Add `unique` rule to `dy.Column`

### DIFF
--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -39,7 +39,14 @@ def _build_rules(
     # Add primary key validation to the list of rules if applicable
     primary_key = _primary_key(columns)
     if len(primary_key) > 0:
-        rules["primary_key"] = Rule(~pl.struct(primary_key).is_duplicated())
+        rules["primary_key"] = Rule(pl.struct(primary_key).is_unique())
+
+    # Add unique column validation rules
+    unique_columns = _unique_columns(columns)
+    for col_name in unique_columns:
+        # wrap the column in a struct to make `is_unique` work with list/arrays
+        # https://github.com/pola-rs/polars/issues/27286
+        rules[f"{col_name}|unique"] = Rule(pl.struct(col_name).is_unique())
 
     # Add column-specific rules
     column_rules = {
@@ -69,6 +76,10 @@ def _build_rules(
 
 def _primary_key(columns: dict[str, Column]) -> list[str]:
     return list(k for k, col in columns.items() if col.primary_key)
+
+
+def _unique_columns(columns: dict[str, Column]) -> list[str]:
+    return list(k for k, col in columns.items() if col.unique)
 
 
 # ------------------------------------------------------------------------------------ #
@@ -299,6 +310,11 @@ class BaseSchema(metaclass=SchemaMeta):
     def primary_key(cls) -> list[str]:
         """The primary key columns in this schema (possibly empty)."""
         return _primary_key(cls.columns())
+
+    @classmethod
+    def unique_columns(cls) -> list[str]:
+        """The columns with unique constraints in this schema (possibly empty)."""
+        return _unique_columns(cls.columns())
 
     @classmethod
     def _validation_rules(cls, *, with_cast: bool) -> dict[str, Rule]:

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -45,6 +45,7 @@ class Column(ABC):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -55,6 +56,9 @@ class Column(ABC):
                 Explicitly set `nullable=True` if you want your column to be nullable.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values. Unlike ``primary_key``,
+                this checks uniqueness for this column independently. Multiple columns
+                can each have ``unique=True`` without forming a composite constraint.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -78,6 +82,7 @@ class Column(ABC):
 
         self.nullable = nullable
         self.primary_key = primary_key
+        self.unique = unique
         self.check = check
         self.alias = alias
         self.metadata = metadata
@@ -198,6 +203,7 @@ class Column(ABC):
             self.sqlalchemy_dtype(dialect),
             nullable=self.nullable,
             primary_key=self.primary_key,
+            unique=self.unique,
             autoincrement=False,
         )
 

--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -7,7 +7,7 @@ import math
 import sys
 import warnings
 from collections.abc import Sequence
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 import polars as pl
 
@@ -34,9 +34,8 @@ class Array(Column):
         shape: int | tuple[int, ...],
         *,
         nullable: bool = False,
-        # polars doesn't yet support grouping by arrays,
-        # see https://github.com/pola-rs/polars/issues/22574
-        primary_key: Literal[False] = False,
+        primary_key: bool = False,
+        unique: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -47,7 +46,7 @@ class Array(Column):
             shape: The shape of the array.
             nullable: Whether this column may contain null values.
             primary_key: Whether this column is part of the primary key of the schema.
-                Not yet supported for the Array type.
+            unique: Whether this column must contain unique values.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -67,7 +66,8 @@ class Array(Column):
         """
         super().__init__(
             nullable=nullable,
-            primary_key=False,
+            primary_key=primary_key,
+            unique=unique,
             check=check,
             alias=alias,
             metadata=metadata,

--- a/dataframely/columns/categorical.py
+++ b/dataframely/columns/categorical.py
@@ -23,6 +23,7 @@ class Categorical(Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -35,6 +36,7 @@ class Categorical(Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -55,6 +57,7 @@ class Categorical(Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             check=check,
             alias=alias,
             metadata=metadata,

--- a/dataframely/columns/datetime.py
+++ b/dataframely/columns/datetime.py
@@ -37,6 +37,7 @@ class Date(OrdinalMixin[dt.date], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         min: dt.date | None = None,
         min_exclusive: dt.date | None = None,
         max: dt.date | None = None,
@@ -54,6 +55,7 @@ class Date(OrdinalMixin[dt.date], Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             min: The minimum date for dates in this column (inclusive).
             min_exclusive: Like `min` but exclusive. May not be specified if `min`
                 is specified and vice versa.
@@ -101,6 +103,7 @@ class Date(OrdinalMixin[dt.date], Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             min=min,
             min_exclusive=min_exclusive,
             max=max,
@@ -170,6 +173,7 @@ class Time(OrdinalMixin[dt.time], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         min: dt.time | None = None,
         min_exclusive: dt.time | None = None,
         max: dt.time | None = None,
@@ -187,6 +191,7 @@ class Time(OrdinalMixin[dt.time], Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             min: The minimum time for times in this column (inclusive).
             min_exclusive: Like `min` but exclusive. May not be specified if `min`
                 is specified and vice versa.
@@ -234,6 +239,7 @@ class Time(OrdinalMixin[dt.time], Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             min=min,
             min_exclusive=min_exclusive,
             max=max,
@@ -309,6 +315,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         min: dt.datetime | None = None,
         min_exclusive: dt.datetime | None = None,
         max: dt.datetime | None = None,
@@ -328,6 +335,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             min: The minimum datetime for datetimes in this column (inclusive).
             min_exclusive: Like `min` but exclusive. May not be specified if `min`
                 is specified and vice versa.
@@ -375,6 +383,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             min=min,
             min_exclusive=min_exclusive,
             max=max,
@@ -472,6 +481,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         min: dt.timedelta | None = None,
         min_exclusive: dt.timedelta | None = None,
         max: dt.timedelta | None = None,
@@ -490,6 +500,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             min: The minimum duration for durations in this column (inclusive).
             min_exclusive: Like `min` but exclusive. May not be specified if `min`
                 is specified and vice versa.
@@ -534,6 +545,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             min=min,
             min_exclusive=min_exclusive,
             max=max,

--- a/dataframely/columns/decimal.py
+++ b/dataframely/columns/decimal.py
@@ -29,6 +29,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         min: decimal.Decimal | int | None = None,
         min_exclusive: decimal.Decimal | int | None = None,
         max: decimal.Decimal | int | None = None,
@@ -47,6 +48,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             min: The minimum value for decimals in this column (inclusive).
             min_exclusive: Like `min` but exclusive. May not be specified if `min`
                 is specified and vice versa.
@@ -91,6 +93,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             min=min,
             min_exclusive=min_exclusive,
             max=max,

--- a/dataframely/columns/enum.py
+++ b/dataframely/columns/enum.py
@@ -28,6 +28,7 @@ class Enum(Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -42,6 +43,7 @@ class Enum(Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -62,6 +64,7 @@ class Enum(Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             check=check,
             alias=alias,
             metadata=metadata,

--- a/dataframely/columns/float.py
+++ b/dataframely/columns/float.py
@@ -29,6 +29,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         allow_inf: bool = False,
         allow_nan: bool = False,
         min: float | None = None,
@@ -47,6 +48,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             allow_inf: Whether this column may contain infinity values.
             allow_nan: Whether this column may contain NaN values.
             min: The minimum value for floats in this column (inclusive).
@@ -83,6 +85,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             min=min,
             min_exclusive=min_exclusive,
             max=max,

--- a/dataframely/columns/integer.py
+++ b/dataframely/columns/integer.py
@@ -26,6 +26,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         min: int | None = None,
         min_exclusive: int | None = None,
         max: int | None = None,
@@ -43,6 +44,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
                 If `True`, `nullable` is automatically set to `False`.
+            unique: Whether this column must contain unique values.
             min: The minimum value for integers in this column (inclusive).
             min_exclusive: Like `min` but exclusive. May not be specified if `min`
                 is specified and vice versa.
@@ -80,6 +82,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             min=min,
             min_exclusive=min_exclusive,
             max=max,

--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -35,6 +35,7 @@ class List(Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         min_length: int | None = None,
@@ -53,6 +54,7 @@ class List(Column):
                 In a future release, `nullable=False` will be the default if `nullable`
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
+            unique: Whether this column must contain unique values.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -73,6 +75,7 @@ class List(Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             check=check,
             alias=alias,
             metadata=metadata,

--- a/dataframely/columns/object.py
+++ b/dataframely/columns/object.py
@@ -22,7 +22,6 @@ class Object(Column):
         self,
         *,
         nullable: bool = False,
-        primary_key: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -30,7 +29,6 @@ class Object(Column):
         """
         Args:
             nullable: Whether this column may contain null values.
-            primary_key: Whether this column is part of the primary key of the schema.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -50,7 +48,6 @@ class Object(Column):
         """
         super().__init__(
             nullable=nullable,
-            primary_key=primary_key,
             check=check,
             alias=alias,
             metadata=metadata,

--- a/dataframely/columns/string.py
+++ b/dataframely/columns/string.py
@@ -26,6 +26,7 @@ class String(Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
         regex: str | None = None,
@@ -40,6 +41,7 @@ class String(Column):
                 In a future release, `nullable=False` will be the default if `nullable`
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
+            unique: Whether this column must contain unique values.
             min_length: The minimum byte-length of string values in this column.
             max_length: The maximum byte-length of string values in this column.
             regex: A regex that the string values in this column must match. If the
@@ -65,6 +67,7 @@ class String(Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             check=check,
             alias=alias,
             metadata=metadata,

--- a/dataframely/columns/struct.py
+++ b/dataframely/columns/struct.py
@@ -31,6 +31,7 @@ class Struct(Column):
         *,
         nullable: bool = False,
         primary_key: bool = False,
+        unique: bool = False,
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
@@ -46,6 +47,7 @@ class Struct(Column):
                 In a future release, `nullable=False` will be the default if `nullable`
                 is not specified.
             primary_key: Whether this column is part of the primary key of the schema.
+            unique: Whether this column must contain unique values.
             check: A custom rule or multiple rules to run for this column. This can be:
                 - A single callable that returns a non-aggregated boolean expression.
                 The name of the rule is derived from the callable name, or defaults to
@@ -66,6 +68,7 @@ class Struct(Column):
         super().__init__(
             nullable=nullable,
             primary_key=primary_key,
+            unique=unique,
             check=check,
             alias=alias,
             metadata=metadata,

--- a/tests/column_types/test_array.py
+++ b/tests/column_types/test_array.py
@@ -145,6 +145,20 @@ def test_array_with_rules() -> None:
     assert failures.counts() == {"a|inner_nullability": 1, "a|inner_min_length": 1}
 
 
+def test_array_with_pk() -> None:
+    schema = create_schema(
+        "test",
+        {"a": dy.Array(dy.String(), 2, nullable=False, primary_key=True)},
+    )
+    df = pl.DataFrame(
+        {"a": [["ab", "cd"], ["ef", "gh"], ["ab", "cd"]]},
+        schema={"a": pl.Array(pl.String, 2)},
+    )
+    _, failures = schema.filter(df)
+    assert validation_mask(df, failures).to_list() == [False, True, False]
+    assert failures.counts() == {"primary_key": 2}
+
+
 def test_array_with_primary_key_rule() -> None:
     schema = create_schema(
         "test", {"a": dy.Array(dy.String(min_length=2, primary_key=True), 2)}

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -268,7 +268,7 @@ def test_sample_override_sequence_with_missing_keys_and_resampling() -> None:
 
 class UniqueSchema(dy.Schema):
     id = dy.Int64(primary_key=True)
-    email = dy.String(unique=True)
+    number = dy.Int16(unique=True)
 
 
 @pytest.mark.parametrize("n", [0, 100])
@@ -277,12 +277,12 @@ def test_sample_unique_constraint(n: int) -> None:
     assert len(df) == n
     UniqueSchema.validate(df)
     # Verify uniqueness
-    assert df.get_column("email").n_unique() == n
+    assert df.get_column("number").n_unique() == n
 
 
 class MultiUniqueSchema(dy.Schema):
-    a = dy.Int64(unique=True)
-    b = dy.String(unique=True)
+    a = dy.Int16(unique=True)
+    b = dy.Int16(unique=True)
 
 
 @pytest.mark.parametrize("n", [0, 100])

--- a/tests/schema/test_sample.py
+++ b/tests/schema/test_sample.py
@@ -261,3 +261,35 @@ def test_sample_override_sequence_with_missing_keys_and_resampling() -> None:
     assert all(df.item(i, 0) == i for i in range(250))
     assert df.item(250, 1) == "two"
     assert df.item(251, 1) == "three"
+
+
+# ----------------------------------- UNIQUE CONSTRAINT --------------------------------- #
+
+
+class UniqueSchema(dy.Schema):
+    id = dy.Int64(primary_key=True)
+    email = dy.String(unique=True)
+
+
+@pytest.mark.parametrize("n", [0, 100])
+def test_sample_unique_constraint(n: int) -> None:
+    df = UniqueSchema.sample(n, generator=Generator(seed=42))
+    assert len(df) == n
+    UniqueSchema.validate(df)
+    # Verify uniqueness
+    assert df.get_column("email").n_unique() == n
+
+
+class MultiUniqueSchema(dy.Schema):
+    a = dy.Int64(unique=True)
+    b = dy.String(unique=True)
+
+
+@pytest.mark.parametrize("n", [0, 100])
+def test_sample_multiple_unique_columns(n: int) -> None:
+    df = MultiUniqueSchema.sample(n, generator=Generator(seed=42))
+    assert len(df) == n
+    MultiUniqueSchema.validate(df)
+    # Verify uniqueness for both columns
+    assert df.get_column("a").n_unique() == n
+    assert df.get_column("b").n_unique() == n

--- a/tests/schema/test_validate.py
+++ b/tests/schema/test_validate.py
@@ -291,22 +291,6 @@ def test_multiple_unique_columns_both_invalid(
     assert not MultiUniqueSchema.is_valid(df)
 
 
-@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
-@pytest.mark.parametrize("eager", [True, False])
-def test_nullable_unique_with_nulls(
-    df_type: type[pl.DataFrame] | type[pl.LazyFrame], eager: bool
-) -> None:
-    # Multiple nulls should NOT cause uniqueness failure (SQL semantics)
-    df = df_type({"a": [1, 2, 3], "b": [None, None, "z"]})
-    # This should fail because is_duplicated() considers nulls as duplicates
-    # Note: This tests current behavior - in SQL, multiple NULLs are allowed in UNIQUE columns
-    with pytest.raises(
-        ValidationError if eager else plexc.ComputeError,
-        match=r"1 rules failed validation",
-    ):
-        _validate_and_collect(NullableUniqueSchema, df, eager=eager)
-
-
 def test_unique_columns_method() -> None:
     assert UniqueSchema.unique_columns() == ["email"]
     assert MultiUniqueSchema.unique_columns() == ["a", "b"]

--- a/tests/schema/test_validate.py
+++ b/tests/schema/test_validate.py
@@ -198,3 +198,117 @@ def test_validate_maintain_order() -> None:
     )
     out = schema.validate(df, cast=True)
     assert out.get_column("a").is_sorted()
+
+
+# ----------------------------------- UNIQUE CONSTRAINT --------------------------------- #
+
+
+class UniqueSchema(dy.Schema):
+    id = dy.Int64(primary_key=True)
+    email = dy.String(unique=True)
+    name = dy.String()
+
+
+class MultiUniqueSchema(dy.Schema):
+    a = dy.Int64(unique=True)
+    b = dy.String(unique=True)
+
+
+class NullableUniqueSchema(dy.Schema):
+    a = dy.Int64()
+    b = dy.String(unique=True, nullable=True)
+
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+@pytest.mark.parametrize("eager", [True, False])
+def test_unique_constraint_valid(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame], eager: bool
+) -> None:
+    df = df_type(
+        {
+            "id": [1, 2, 3],
+            "email": ["a@x.com", "b@x.com", "c@x.com"],
+            "name": ["A", "B", "C"],
+        }
+    )
+    result = _validate_and_collect(UniqueSchema, df, eager=eager)
+    assert len(result) == 3
+    assert UniqueSchema.is_valid(df)
+
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+@pytest.mark.parametrize("eager", [True, False])
+def test_unique_constraint_invalid(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame], eager: bool
+) -> None:
+    df = df_type({"id": [1, 2], "email": ["a@x.com", "a@x.com"], "name": ["A", "B"]})
+    with pytest.raises(
+        ValidationError if eager else plexc.ComputeError,
+        match=r"1 rules failed validation",
+    ):
+        _validate_and_collect(UniqueSchema, df, eager=eager)
+    assert not UniqueSchema.is_valid(df)
+
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+@pytest.mark.parametrize("eager", [True, False])
+def test_multiple_unique_columns_valid(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame], eager: bool
+) -> None:
+    df = df_type({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    result = _validate_and_collect(MultiUniqueSchema, df, eager=eager)
+    assert len(result) == 3
+    assert MultiUniqueSchema.is_valid(df)
+
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+@pytest.mark.parametrize("eager", [True, False])
+def test_multiple_unique_columns_one_invalid(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame], eager: bool
+) -> None:
+    # a is unique, b has duplicates
+    df = df_type({"a": [1, 2, 3], "b": ["x", "x", "z"]})
+    with pytest.raises(
+        ValidationError if eager else plexc.ComputeError,
+        match=r"1 rules failed validation",
+    ):
+        _validate_and_collect(MultiUniqueSchema, df, eager=eager)
+    assert not MultiUniqueSchema.is_valid(df)
+
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+@pytest.mark.parametrize("eager", [True, False])
+def test_multiple_unique_columns_both_invalid(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame], eager: bool
+) -> None:
+    # Both columns have duplicates
+    df = df_type({"a": [1, 1, 3], "b": ["x", "y", "y"]})
+    with pytest.raises(
+        ValidationError if eager else plexc.ComputeError,
+        match=r"2 rules failed validation",
+    ):
+        _validate_and_collect(MultiUniqueSchema, df, eager=eager)
+    assert not MultiUniqueSchema.is_valid(df)
+
+
+@pytest.mark.parametrize("df_type", [pl.DataFrame, pl.LazyFrame])
+@pytest.mark.parametrize("eager", [True, False])
+def test_nullable_unique_with_nulls(
+    df_type: type[pl.DataFrame] | type[pl.LazyFrame], eager: bool
+) -> None:
+    # Multiple nulls should NOT cause uniqueness failure (SQL semantics)
+    df = df_type({"a": [1, 2, 3], "b": [None, None, "z"]})
+    # This should fail because is_duplicated() considers nulls as duplicates
+    # Note: This tests current behavior - in SQL, multiple NULLs are allowed in UNIQUE columns
+    with pytest.raises(
+        ValidationError if eager else plexc.ComputeError,
+        match=r"1 rules failed validation",
+    ):
+        _validate_and_collect(NullableUniqueSchema, df, eager=eager)
+
+
+def test_unique_columns_method() -> None:
+    assert UniqueSchema.unique_columns() == ["email"]
+    assert MultiUniqueSchema.unique_columns() == ["a", "b"]
+    assert NullableUniqueSchema.unique_columns() == ["b"]
+    assert MySchema.unique_columns() == []


### PR DESCRIPTION
# Motivation

Closes #313 

# Changes

Add the new rule using the same logic than primary_keys.

Drive by:
- Allow `primary_keys` for array dtype as it now works in polars, I added a test of it.
- Disallow  `primary_keys` for object dtype as it never worked. (technically breaking but IMHO shouldn't break anything)