### PR TITLE
fix: Default to non nullable column for array and object

### DIFF
--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -33,7 +33,7 @@ class Array(Column):
         inner: Column,
         shape: int | tuple[int, ...],
         *,
-        nullable: bool = True,
+        nullable: bool = False,
         # polars doesn't yet support grouping by arrays,
         # see https://github.com/pola-rs/polars/issues/22574
         primary_key: Literal[False] = False,

--- a/dataframely/columns/object.py
+++ b/dataframely/columns/object.py
@@ -21,7 +21,7 @@ class Object(Column):
     def __init__(
         self,
         *,
-        nullable: bool = True,
+        nullable: bool = False,
         primary_key: bool = False,
         check: Check | None = None,
         alias: str | None = None,

--- a/tests/columns/test_pyarrow.py
+++ b/tests/columns/test_pyarrow.py
@@ -90,7 +90,7 @@ def test_equal_polars_schema_list(inner: Column) -> None:
     ],
 )
 def test_equal_polars_schema_array(inner: Column, shape: int | tuple[int, ...]) -> None:
-    schema = create_schema("test", {"a": dy.Array(inner, shape)})
+    schema = create_schema("test", {"a": dy.Array(inner, shape, nullable=True)})
     actual = schema.to_pyarrow_schema()
     expected = schema.create_empty().to_arrow().schema
     assert actual == expected

--- a/tests/columns/test_sample.py
+++ b/tests/columns/test_sample.py
@@ -184,7 +184,7 @@ def test_sample_list(generator: Generator) -> None:
 
 
 def test_sample_array(generator: Generator) -> None:
-    column = dy.Array(dy.Bool(nullable=True), (2, 3))
+    column = dy.Array(dy.Bool(nullable=True), (2, 3), nullable=True)
     samples = sample_and_validate(column, generator, n=10_000)
     assert samples.is_null().any()
     assert set(samples.arr.len()) == {2, None}


### PR DESCRIPTION
I think is as been missed when merging the [PR](https://github.com/Quantco/dataframely/pull/174).
Or maybe it wasn't possible to implement at the time. In any case I don't see why object and array are nullable by default.

This is breaking, how do you want to proceed ? 

