### PR TITLE
fix: Remove `infer_schema` from top-level `__all__`

### DIFF
--- a/dataframely/__init__.py
+++ b/dataframely/__init__.py
@@ -78,7 +78,6 @@ __all__ = [
     "deserialize_schema",
     "read_parquet_metadata_schema",
     "read_parquet_metadata_collection",
-    "infer_schema",
     "Any",
     "Binary",
     "Bool",


### PR DESCRIPTION
# Motivation

I forgot to remove this while finalizing #294
`pyrefly` caught it :)


# Changes

* Removed nonexisting function from top-level `__all__` list 