### PR TITLE
fix: Propagate column overrides through grandchild schemas

### DIFF
--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import sys
 import textwrap
 from abc import ABCMeta
+from collections.abc import Mapping
 from copy import copy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -207,7 +208,7 @@ class SchemaMeta(ABCMeta):
     @staticmethod
     def _remove_overridden_columns(
         result: Metadata,
-        namespace: dict[str, Any],
+        namespace: Mapping[str, Any],
         bases: tuple[type[object], ...],
     ) -> None:
         """Remove inherited columns that the child namespace explicitly overrides.
@@ -235,7 +236,7 @@ class SchemaMeta(ABCMeta):
     @staticmethod
     def _collect_metadata(
         bases: tuple[type[object], ...],
-        namespace: dict[str, Any],
+        namespace: Mapping[str, Any],
     ) -> Metadata:
         result = Metadata()
         for base in bases:
@@ -246,10 +247,10 @@ class SchemaMeta(ABCMeta):
 
     @staticmethod
     def _get_metadata_recursively(kls: type[object]) -> Metadata:
-        return SchemaMeta._collect_metadata(kls.__bases__, kls.__dict__)  # type: ignore[arg-type]
+        return SchemaMeta._collect_metadata(kls.__bases__, kls.__dict__)
 
     @staticmethod
-    def _get_metadata(source: dict[str, Any]) -> Metadata:
+    def _get_metadata(source: Mapping[str, Any]) -> Metadata:
         result = Metadata()
         for attr, value in {
             k: v for k, v in source.items() if not k.startswith("__")

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -116,12 +116,7 @@ class SchemaMeta(ABCMeta):
         *args: Any,
         **kwargs: Any,
     ) -> SchemaMeta:
-        result = Metadata()
-        for base in bases:
-            result.update(mcs._get_metadata_recursively(base))
-        namespace_metadata = mcs._get_metadata(namespace)
-        mcs._remove_overridden_columns(result, namespace, bases)
-        result.update(namespace_metadata)
+        result = mcs._collect_metadata(bases, namespace)
         namespace[_COLUMN_ATTR] = result.columns
         cls = super().__new__(mcs, name, bases, namespace, *args, **kwargs)
 
@@ -238,17 +233,20 @@ class SchemaMeta(ABCMeta):
                 result.columns.pop(parent_key, None)
 
     @staticmethod
-    def _get_metadata_recursively(kls: type[object]) -> Metadata:
+    def _collect_metadata(
+        bases: tuple[type[object], ...],
+        namespace: dict[str, Any],
+    ) -> Metadata:
         result = Metadata()
-        for base in kls.__bases__:
+        for base in bases:
             result.update(SchemaMeta._get_metadata_recursively(base))
-        SchemaMeta._remove_overridden_columns(
-            result,
-            kls.__dict__,  # type: ignore[arg-type]
-            kls.__bases__,
-        )
-        result.update(SchemaMeta._get_metadata(kls.__dict__))  # type: ignore
+        SchemaMeta._remove_overridden_columns(result, namespace, bases)
+        result.update(SchemaMeta._get_metadata(namespace))
         return result
+
+    @staticmethod
+    def _get_metadata_recursively(kls: type[object]) -> Metadata:
+        return SchemaMeta._collect_metadata(kls.__bases__, kls.__dict__)  # type: ignore[arg-type]
 
     @staticmethod
     def _get_metadata(source: dict[str, Any]) -> Metadata:

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -242,6 +242,11 @@ class SchemaMeta(ABCMeta):
         result = Metadata()
         for base in kls.__bases__:
             result.update(SchemaMeta._get_metadata_recursively(base))
+        SchemaMeta._remove_overridden_columns(
+            result,
+            kls.__dict__,  # type: ignore[arg-type]
+            kls.__bases__,
+        )
         result.update(SchemaMeta._get_metadata(kls.__dict__))  # type: ignore
         return result
 

--- a/tests/schema/test_inheritance.py
+++ b/tests/schema/test_inheritance.py
@@ -20,3 +20,27 @@ def test_columns() -> None:
     assert ParentSchema.column_names() == ["a"]
     assert ChildSchema.column_names() == ["a", "b"]
     assert GrandchildSchema.column_names() == ["a", "b", "c"]
+
+
+class OverrideBase(dy.Schema):
+    amt = dy.Float64(nullable=True)
+
+
+class OverrideChild(OverrideBase):
+    amt = dy.Float64(nullable=False)
+
+
+class OverrideGrandchild(OverrideChild):
+    pass
+
+
+class OverrideGreatGrandchild(OverrideGrandchild):
+    other = dy.Integer()
+
+
+def test_column_override_propagates_to_grandchild() -> None:
+    assert OverrideBase.columns()["amt"].nullable is True
+    assert OverrideChild.columns()["amt"].nullable is False
+    assert OverrideGrandchild.columns()["amt"].nullable is False
+    assert OverrideGreatGrandchild.columns()["amt"].nullable is False
+    assert OverrideGreatGrandchild.column_names() == ["amt", "other"]


### PR DESCRIPTION
# Motivation

Fixes #329. Starting in 2.8.0, defining a grandchild schema that inherits from a child which overrides a parent column raises `ImplementationError: Columns {...} are duplicated with conflicting definitions.`:

```python
class Base(dy.Schema):
    amt = dy.Float64(nullable=True)

class Child(Base):
    amt = dy.Float64(nullable=False)

class Grandchild(Child):  # ImplementationError
    pass
```

`SchemaMeta.__new__` drops parent columns shadowed by the current namespace via `_remove_overridden_columns`, but `_get_metadata_recursively` — used when walking bases during grandchild creation — never applied the same logic. So both `Child`'s override and `Base`'s original `amt` landed in the merged metadata and tripped the conflict check.

# Changes

- Call `_remove_overridden_columns` inside `_get_metadata_recursively` so column overrides propagate through inheritance chains of any depth.
- Add regression tests covering grandchild and great-grandchild inheritance of overridden columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)