### PR TITLE
build: Use cargo-auditable for rust build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,10 +81,10 @@ jobs:
           command: build
           args: --out dist --release -i python3.10
           manylinux: auto
-          sccache: github.event_name != 'release'
+          sccache: ${{ github.event_name != 'release' }}
           # NOTE: We also need to set up cargo-auditable inside the docker container
           # where the linux build is performed.
-          docker-options: case(github.event_name == 'release', "-e CARGO=${{ env.CARGO }}", '')
+          docker-options: ${{ case(github.event_name == 'release', "-e CARGO=${{ env.CARGO }}", '') }}
           before-script-linux: |
             ${{ case(github.event_name == 'release', 'cargo install cargo-auditable@0.7.4 --locked && printf ''#!/bin/sh\nexec cargo auditable "$@"\n'' > /usr/local/bin/cargo-auditable-wrapper && chmod +x /usr/local/bin/cargo-auditable-wrapper', '') }}
       - name: Check package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,13 +60,26 @@ jobs:
       - name: Install cargo-auditable
         shell: bash
         run: |
+          # cargo-auditable must be invoked as "cargo auditable <cmd>" (subcommand form), not as a
+          # direct CARGO replacement — the latter does not support "cargo rustc --profile".
+          # A thin wrapper script bridges the gap by forwarding all args through the subcommand.
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            # before-script-linux installs cargo-auditable inside the manylinux container.
-            # Set CARGO on the host here so maturin-action passes it into the container.
-            echo "CARGO=/usr/local/bin/cargo-auditable" >> "$GITHUB_ENV"
+            # before-script-linux handles installation inside the manylinux container.
+            # Set CARGO on the host so maturin-action passes it into the container.
+            echo "CARGO=/usr/local/bin/cargo-auditable-wrapper" >> "$GITHUB_ENV"
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            REAL_CARGO="$(cygpath -w "$(which cargo)")"
+            cargo install cargo-auditable@0.7.4 --locked
+            WRAPPER="C:/cargo-auditable-wrapper.cmd"
+            printf '@"%s" auditable %%*\n' "$REAL_CARGO" > "$WRAPPER"
+            echo "CARGO=$(cygpath -w "$WRAPPER")" >> "$GITHUB_ENV"
           else
             cargo install cargo-auditable@0.7.4 --locked
-            echo "CARGO=$(which cargo-auditable)" >> "$GITHUB_ENV"
+            REAL_CARGO="$(which cargo)"
+            WRAPPER="/usr/local/bin/cargo-auditable-wrapper"
+            printf '#!/bin/sh\nREAL_CARGO="%s"\nexec "$REAL_CARGO" auditable "$@"\n' "$REAL_CARGO" > "$WRAPPER"
+            chmod +x "$WRAPPER"
+            echo "CARGO=$WRAPPER" >> "$GITHUB_ENV"
           fi
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
@@ -77,7 +90,9 @@ jobs:
           sccache: false
           before-script-linux: |
             cargo install cargo-auditable@0.7.4 --locked
-            cp ~/.cargo/bin/cargo-auditable /usr/local/bin/cargo-auditable
+            REAL_CARGO="$(which cargo)"
+            printf '#!/bin/sh\nREAL_CARGO="%s"\nexec "$REAL_CARGO" auditable "$@"\n' "$REAL_CARGO" > /usr/local/bin/cargo-auditable-wrapper
+            chmod +x /usr/local/bin/cargo-auditable-wrapper
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           # where the linux build is performed.
           docker-options: case(github.event_name == 'release', "-e CARGO=${{ env.CARGO }}", '')
           before-script-linux: |
-            ${{ case(github.event_name == 'release', 'cargo install cargo-auditable@0.7.4 --locked && printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper && chmod +x /usr/local/bin/cargo-auditable-wrapper', '') }}
+            ${{ case(github.event_name == 'release', 'cargo install cargo-auditable@0.7.4 --locked && printf ''#!/bin/sh\nexec cargo auditable "$@"\n'' > /usr/local/bin/cargo-auditable-wrapper && chmod +x /usr/local/bin/cargo-auditable-wrapper', '') }}
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,13 +57,19 @@ jobs:
           environments: build
       - name: Set version
         run: pixi run -e build set-version
+      - name: Install cargo-auditable
+        if: ${{ !contains(matrix.os, 'ubuntu') }}
+        run: cargo install cargo-auditable
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
+        env:
+          RUSTC_WORKSPACE_WRAPPER: cargo-auditable
         with:
           command: build
           args: --out dist --release -i python3.10
           manylinux: auto
           sccache: true
+          before-script-linux: cargo install cargo-auditable
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,23 +57,19 @@ jobs:
           environments: build
       - name: Set version
         run: pixi run -e build set-version
-      - name: Install cargo-auditable (macOS)
-        if: ${{ contains(matrix.os, 'macos') }}
+      - name: Install cargo-auditable
+        shell: bash
         run: |
-          cargo install cargo-auditable@0.7.4 --locked
-          printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
-          chmod +x /usr/local/bin/cargo-auditable-wrapper
-      - name: Install cargo-auditable (Windows)
-        if: ${{ contains(matrix.os, 'windows') }}
-        run: |
-          cargo install cargo-auditable@0.7.4 --locked
-          Set-Content -Path "C:\Windows\System32\cargo-auditable-wrapper.cmd" -Value "@cargo auditable %*"
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            # before-script-linux installs cargo-auditable inside the manylinux container.
+            # Set CARGO on the host here so maturin-action passes it into the container.
+            echo "CARGO=/usr/local/bin/cargo-auditable" >> "$GITHUB_ENV"
+          else
+            cargo install cargo-auditable@0.7.4 --locked
+            echo "CARGO=$(which cargo-auditable)" >> "$GITHUB_ENV"
+          fi
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
-        env:
-          # cargo-auditable is a cargo subcommand wrapper, not a rustc shim.
-          # Set CARGO to a thin wrapper that prepends "auditable" to every invocation.
-          CARGO: cargo-auditable-wrapper
         with:
           command: build
           args: --out dist --release -i python3.10
@@ -81,8 +77,7 @@ jobs:
           sccache: false
           before-script-linux: |
             cargo install cargo-auditable@0.7.4 --locked
-            printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
-            chmod +x /usr/local/bin/cargo-auditable-wrapper
+            cp ~/.cargo/bin/cargo-auditable /usr/local/bin/cargo-auditable
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         run: pixi run -e build set-version
       - name: Install cargo-auditable
         shell: bash
+        if: github.event_name == 'release'
         run: |
           # cargo-auditable must be invoked as "cargo auditable <cmd>", not as a direct CARGO
           # replacement — the latter does not support "cargo rustc --profile". A wrapper delegates
@@ -80,12 +81,12 @@ jobs:
           command: build
           args: --out dist --release -i python3.10
           manylinux: auto
-          sccache: false
-          docker-options: "-e CARGO=${{ env.CARGO }}"
+          sccache: github.event_name != 'release'
+          # NOTE: We also need to set up cargo-auditable inside the docker container
+          # where the linux build is performed.
+          docker-options: case(github.event_name == 'release', "-e CARGO=${{ env.CARGO }}", '')
           before-script-linux: |
-            cargo install cargo-auditable@0.7.4 --locked
-            printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
-            chmod +x /usr/local/bin/cargo-auditable-wrapper
+            ${{ case(github.event_name == 'release', 'cargo install cargo-auditable@0.7.4 --locked && printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper && chmod +x /usr/local/bin/cargo-auditable-wrapper', '') }}
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           sccache: ${{ github.event_name != 'release' }}
           # NOTE: We also need to set up cargo-auditable inside the docker container
           # where the linux build is performed.
-          docker-options: ${{ case(github.event_name == 'release', "-e CARGO=${{ env.CARGO }}", '') }}
+          docker-options: ${{ case(github.event_name == 'release', format('-e CARGO={0}', env.CARGO), '') }}
           before-script-linux: |
             ${{ case(github.event_name == 'release', 'cargo install cargo-auditable@0.7.4 --locked && printf ''#!/bin/sh\nexec cargo auditable "$@"\n'' > /usr/local/bin/cargo-auditable-wrapper && chmod +x /usr/local/bin/cargo-auditable-wrapper', '') }}
       - name: Check package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,26 +60,19 @@ jobs:
       - name: Install cargo-auditable
         shell: bash
         run: |
-          # cargo-auditable must be invoked as "cargo auditable <cmd>" (subcommand form), not as a
-          # direct CARGO replacement — the latter does not support "cargo rustc --profile".
-          # A thin wrapper script bridges the gap by forwarding all args through the subcommand.
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            # before-script-linux handles installation inside the manylinux container.
-            # Set CARGO on the host so maturin-action passes it into the container.
-            echo "CARGO=/usr/local/bin/cargo-auditable-wrapper" >> "$GITHUB_ENV"
-          elif [[ "$RUNNER_OS" == "Windows" ]]; then
-            REAL_CARGO="$(cygpath -w "$(which cargo)")"
+          # cargo-auditable must be invoked as "cargo auditable <cmd>", not as a direct CARGO
+          # replacement — the latter does not support "cargo rustc --profile". A wrapper delegates
+          # to the real cargo via PATH (no recursion risk since CARGO is set via env, not PATH).
+          if [[ "$RUNNER_OS" != "Linux" ]]; then
             cargo install cargo-auditable@0.7.4 --locked
-            WRAPPER="C:/cargo-auditable-wrapper.cmd"
-            printf '@"%s" auditable %%*\n' "$REAL_CARGO" > "$WRAPPER"
-            echo "CARGO=$(cygpath -w "$WRAPPER")" >> "$GITHUB_ENV"
+          fi
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            printf '@cargo auditable %%*\n' > "C:/cargo-auditable-wrapper.cmd"
+            echo "CARGO=C:\\cargo-auditable-wrapper.cmd" >> "$GITHUB_ENV"
           else
-            cargo install cargo-auditable@0.7.4 --locked
-            REAL_CARGO="$(which cargo)"
-            WRAPPER="/usr/local/bin/cargo-auditable-wrapper"
-            printf '#!/bin/sh\nREAL_CARGO="%s"\nexec "$REAL_CARGO" auditable "$@"\n' "$REAL_CARGO" > "$WRAPPER"
-            chmod +x "$WRAPPER"
-            echo "CARGO=$WRAPPER" >> "$GITHUB_ENV"
+            printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
+            chmod +x /usr/local/bin/cargo-auditable-wrapper
+            echo "CARGO=/usr/local/bin/cargo-auditable-wrapper" >> "$GITHUB_ENV"
           fi
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
@@ -91,8 +84,7 @@ jobs:
           docker-options: "-e CARGO=${{ env.CARGO }}"
           before-script-linux: |
             cargo install cargo-auditable@0.7.4 --locked
-            REAL_CARGO="$(which cargo)"
-            printf '#!/bin/sh\nREAL_CARGO="%s"\nexec "$REAL_CARGO" auditable "$@"\n' "$REAL_CARGO" > /usr/local/bin/cargo-auditable-wrapper
+            printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
             chmod +x /usr/local/bin/cargo-auditable-wrapper
       - name: Check package
         run: pixi run -e build check-wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
           args: --out dist --release -i python3.10
           manylinux: auto
           sccache: false
+          docker-options: "-e CARGO=${{ env.CARGO }}"
           before-script-linux: |
             cargo install cargo-auditable@0.7.4 --locked
             REAL_CARGO="$(which cargo)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,20 +57,32 @@ jobs:
           environments: build
       - name: Set version
         run: pixi run -e build set-version
-      - name: Install cargo-auditable
-        if: ${{ !contains(matrix.os, 'ubuntu') }}
-        run: cargo install cargo-auditable@0.7.4 --locked
+      - name: Install cargo-auditable (macOS)
+        if: ${{ contains(matrix.os, 'macos') }}
+        run: |
+          cargo install cargo-auditable@0.7.4 --locked
+          printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
+          chmod +x /usr/local/bin/cargo-auditable-wrapper
+      - name: Install cargo-auditable (Windows)
+        if: ${{ contains(matrix.os, 'windows') }}
+        run: |
+          cargo install cargo-auditable@0.7.4 --locked
+          Set-Content -Path "C:\Windows\System32\cargo-auditable-wrapper.cmd" -Value "@cargo auditable %*"
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         env:
-          # cargo-auditable and sccache both wrap rustc and cannot be composed.
-          RUSTC_WORKSPACE_WRAPPER: cargo-auditable
+          # cargo-auditable is a cargo subcommand wrapper, not a rustc shim.
+          # Set CARGO to a thin wrapper that prepends "auditable" to every invocation.
+          CARGO: cargo-auditable-wrapper
         with:
           command: build
           args: --out dist --release -i python3.10
           manylinux: auto
           sccache: false
-          before-script-linux: cargo install cargo-auditable@0.7.4 --locked
+          before-script-linux: |
+            cargo install cargo-auditable@0.7.4 --locked
+            printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
+            chmod +x /usr/local/bin/cargo-auditable-wrapper
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,18 +58,20 @@ jobs:
       - name: Set version
         run: pixi run -e build set-version
       - name: Install cargo-auditable
-        if: ${{ !contains(matrix.os, 'ubuntu') }}
+        if: ${{ github.event_name == 'release' && !contains(matrix.os, 'ubuntu') }}
         run: cargo install cargo-auditable
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         env:
-          RUSTC_WORKSPACE_WRAPPER: cargo-auditable
+          # cargo-auditable and sccache both wrap rustc and cannot be composed.
+          # Only embed audit metadata for release builds; use sccache otherwise.
+          RUSTC_WORKSPACE_WRAPPER: ${{ github.event_name == 'release' && 'cargo-auditable' || '' }}
         with:
           command: build
           args: --out dist --release -i python3.10
           manylinux: auto
-          sccache: true
-          before-script-linux: cargo install cargo-auditable
+          sccache: ${{ github.event_name != 'release' }}
+          before-script-linux: ${{ github.event_name == 'release' && 'cargo install cargo-auditable' || '' }}
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,20 +58,19 @@ jobs:
       - name: Set version
         run: pixi run -e build set-version
       - name: Install cargo-auditable
-        if: ${{ github.event_name == 'release' && !contains(matrix.os, 'ubuntu') }}
-        run: cargo install cargo-auditable
+        if: ${{ !contains(matrix.os, 'ubuntu') }}
+        run: cargo install cargo-auditable@0.7.4 --locked
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         env:
           # cargo-auditable and sccache both wrap rustc and cannot be composed.
-          # Only embed audit metadata for release builds; use sccache otherwise.
-          RUSTC_WORKSPACE_WRAPPER: ${{ github.event_name == 'release' && 'cargo-auditable' || '' }}
+          RUSTC_WORKSPACE_WRAPPER: cargo-auditable
         with:
           command: build
           args: --out dist --release -i python3.10
           manylinux: auto
-          sccache: ${{ github.event_name != 'release' }}
-          before-script-linux: ${{ github.event_name == 'release' && 'cargo install cargo-auditable' || '' }}
+          sccache: false
+          before-script-linux: cargo install cargo-auditable@0.7.4 --locked
       - name: Check package
         run: pixi run -e build check-wheel
       - name: Upload package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set version
         run: pixi run -e build set-version
       - name: Install cargo-auditable
-        if: github.event_name == 'release' && !startsWith(matrix.os, 'linux')
+        if: github.event_name == 'release' && !startsWith(matrix.os, 'ubuntu')
         run: cargo install cargo-auditable@0.7.4 --locked
         shell: bash
       - name: Prepare cargo-auditable wrapper (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,23 +58,24 @@ jobs:
       - name: Set version
         run: pixi run -e build set-version
       - name: Install cargo-auditable
+        if: github.event_name == 'release' && !startsWith(matrix.os, 'linux')
+        run: cargo install cargo-auditable@0.7.4 --locked
         shell: bash
-        if: github.event_name == 'release'
+      - name: Prepare cargo-auditable wrapper (macOS)
+        if: github.event_name == 'release' && startsWith(matrix.os, 'macos')
         run: |
           # cargo-auditable must be invoked as "cargo auditable <cmd>", not as a direct CARGO
           # replacement — the latter does not support "cargo rustc --profile". A wrapper delegates
           # to the real cargo via PATH (no recursion risk since CARGO is set via env, not PATH).
-          if [[ "$RUNNER_OS" != "Linux" ]]; then
-            cargo install cargo-auditable@0.7.4 --locked
-          fi
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            printf '@cargo auditable %%*\n' > "C:/cargo-auditable-wrapper.cmd"
-            echo "CARGO=C:\\cargo-auditable-wrapper.cmd" >> "$GITHUB_ENV"
-          else
-            printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
-            chmod +x /usr/local/bin/cargo-auditable-wrapper
-            echo "CARGO=/usr/local/bin/cargo-auditable-wrapper" >> "$GITHUB_ENV"
-          fi
+          printf '#!/bin/sh\nexec cargo auditable "$@"\n' > /usr/local/bin/cargo-auditable-wrapper
+          chmod +x /usr/local/bin/cargo-auditable-wrapper
+          echo "CARGO=/usr/local/bin/cargo-auditable-wrapper" >> "$GITHUB_ENV"
+      - name: Prepare cargo-auditable wrapper (Windows)
+        if: github.event_name == 'release' && matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          printf '@cargo auditable %%*\n' > "C:/cargo-auditable-wrapper.cmd"
+          echo "CARGO=C:\\cargo-auditable-wrapper.cmd" >> "$GITHUB_ENV"
       - name: Build wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set version
         run: pixi run -e build set-version
       - name: Install cargo-auditable
-        if: github.event_name == 'release' && !startsWith(matrix.os, 'ubuntu')
+        if: github.event_name == 'release' && runner.os != 'Linux'
         run: cargo install cargo-auditable@0.7.4 --locked
       - name: Prepare cargo-auditable wrapper (macOS)
         if: github.event_name == 'release' && runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,8 @@ jobs:
       - name: Install cargo-auditable
         if: github.event_name == 'release' && !startsWith(matrix.os, 'ubuntu')
         run: cargo install cargo-auditable@0.7.4 --locked
-        shell: bash
       - name: Prepare cargo-auditable wrapper (macOS)
-        if: github.event_name == 'release' && startsWith(matrix.os, 'macos')
+        if: github.event_name == 'release' && runner.os == 'macOS'
         run: |
           # cargo-auditable must be invoked as "cargo auditable <cmd>", not as a direct CARGO
           # replacement — the latter does not support "cargo rustc --profile". A wrapper delegates
@@ -71,7 +70,7 @@ jobs:
           chmod +x /usr/local/bin/cargo-auditable-wrapper
           echo "CARGO=/usr/local/bin/cargo-auditable-wrapper" >> "$GITHUB_ENV"
       - name: Prepare cargo-auditable wrapper (Windows)
-        if: github.event_name == 'release' && matrix.os == 'windows-latest'
+        if: github.event_name == 'release' && runner.os == 'Windows'
         shell: bash
         run: |
           printf '@cargo auditable %%*\n' > "C:/cargo-auditable-wrapper.cmd"


### PR DESCRIPTION
# Motivation

Make release rust binaries auditable, e.g., for vulnerability scanning of included crates.

# Changes

Use `cargo-auditable` for release builds on PyPI. `cargo-auditable` works by embedding data about the dependency tree in JSON format into a dedicated linker section of the compiled executable.