### PR TITLE
feat: Add `description` field to columns

### DIFF
--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -453,7 +453,7 @@ class Column(ABC):
                     else getattr(self, param)
                 )
                 for param in inspect.signature(self.__class__.__init__).parameters
-                if param not in ("self", "alias")
+                if param not in ("self", "alias", "description")
             },
         }
 
@@ -502,8 +502,9 @@ class Column(ABC):
             for attr in attributes.parameters
             # NOTE: We do not want to compare the `alias` here as the comparison should
             #  only evaluate the type and its constraints. Names are checked in
-            #  :meth:`Schema.matches`.
-            if attr not in ("self", "alias")
+            #  :meth:`Schema.matches`. The `description` is also excluded as it is
+            #  human-readable documentation rather than a semantic constraint.
+            if attr not in ("self", "alias", "description")
         )
 
     def _attributes_match(
@@ -523,7 +524,9 @@ class Column(ABC):
                 self.__class__.__init__
             ).parameters.items()
             if attribute
-            not in ["self", "alias"]  # alias is always equal to the column name here
+            # alias is always equal to the column name here; description is
+            # human-readable documentation rather than a semantic constraint
+            not in ["self", "alias", "description"]
             and not (
                 # Do not include attributes that are set to their default value
                 getattr(self, attribute) == param_details.default

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -49,6 +49,7 @@ class Column(ABC):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -79,6 +80,7 @@ class Column(ABC):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if nullable and primary_key:
             raise ValueError("Nullable primary key columns are not supported.")
@@ -89,6 +91,7 @@ class Column(ABC):
         self.check = check
         self.alias = alias
         self.metadata = metadata
+        self.description = description
         # The name may be overridden by the schema on column access.
         self._name = ""
 
@@ -277,7 +280,10 @@ class Column(ABC):
         Returns:
             A dictionary of kwargs to pass to pydantic.Field.
         """
-        return {}
+        kwargs: dict[str, Any] = {}
+        if self.description is not None:
+            kwargs["description"] = self.description
+        return kwargs
 
     # ------------------------------------ HELPER ------------------------------------ #
 
@@ -361,6 +367,17 @@ class Column(ABC):
             A new column instance with the specified metadata.
         """
         return self.with_properties(metadata=metadata)
+
+    def with_description(self, description: str) -> Self:
+        """Return a new column definition with the specified description.
+
+        Args:
+            description: A human-readable description of the column.
+
+        Returns:
+            A new column instance with the specified description.
+        """
+        return self.with_properties(description=description)
 
     # ----------------------------------- SAMPLING ----------------------------------- #
 

--- a/dataframely/columns/any.py
+++ b/dataframely/columns/any.py
@@ -30,6 +30,7 @@ class Any(Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -53,6 +54,7 @@ class Any(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=True,
@@ -60,6 +62,7 @@ class Any(Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
 
     @property

--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -39,6 +39,7 @@ class Array(Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -69,6 +70,7 @@ class Array(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=nullable,
@@ -77,6 +79,7 @@ class Array(Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.inner = inner
         self.shape = shape if isinstance(shape, tuple) else (shape,)

--- a/dataframely/columns/categorical.py
+++ b/dataframely/columns/categorical.py
@@ -27,6 +27,7 @@ class Categorical(Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -59,6 +60,7 @@ class Categorical(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=nullable,
@@ -67,6 +69,7 @@ class Categorical(Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
 
     @property

--- a/dataframely/columns/datetime.py
+++ b/dataframely/columns/datetime.py
@@ -46,6 +46,7 @@ class Date(OrdinalMixin[dt.date], Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -88,6 +89,7 @@ class Date(OrdinalMixin[dt.date], Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if resolution is not None:
             offset_time = pl.Series([EPOCH_DATETIME]).dt.offset_by(resolution).dt.time()
@@ -117,6 +119,7 @@ class Date(OrdinalMixin[dt.date], Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.resolution = resolution
 
@@ -188,6 +191,7 @@ class Time(OrdinalMixin[dt.time], Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -230,6 +234,7 @@ class Time(OrdinalMixin[dt.time], Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if resolution is not None:
             offset_date = pl.Series([EPOCH_DATETIME]).dt.offset_by(resolution).dt.date()
@@ -259,6 +264,7 @@ class Time(OrdinalMixin[dt.time], Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.resolution = resolution
 
@@ -338,6 +344,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -384,6 +391,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if resolution is not None and min is not None:
             if not datetime_matches_resolution(min, resolution):
@@ -409,6 +417,7 @@ class Datetime(OrdinalMixin[dt.datetime], Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.resolution = resolution
         self.time_zone = time_zone
@@ -509,6 +518,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -552,6 +562,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if resolution is not None and min is not None:
             if not timedelta_matches_resolution(min, resolution):
@@ -577,6 +588,7 @@ class Duration(OrdinalMixin[dt.timedelta], Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.resolution = resolution
         self.time_unit = time_unit

--- a/dataframely/columns/decimal.py
+++ b/dataframely/columns/decimal.py
@@ -37,6 +37,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -77,6 +78,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if isinstance(min, int):
             min = decimal.Decimal(min)
@@ -107,6 +109,7 @@ class Decimal(OrdinalMixin[decimal.Decimal], Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.precision = precision
         self.scale = scale

--- a/dataframely/columns/enum.py
+++ b/dataframely/columns/enum.py
@@ -32,6 +32,7 @@ class Enum(Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -66,6 +67,7 @@ class Enum(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=nullable,
@@ -74,6 +76,7 @@ class Enum(Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         if isclass(categories) and issubclass(categories, enum.Enum):
             categories = (item.value for item in categories)

--- a/dataframely/columns/float.py
+++ b/dataframely/columns/float.py
@@ -39,6 +39,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -79,6 +80,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if min is not None and min < self.min_value:
             raise ValueError("Minimum value is too small for the data type.")
@@ -99,6 +101,7 @@ class _BaseFloat(OrdinalMixin[float], Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
 
     @classproperty

--- a/dataframely/columns/integer.py
+++ b/dataframely/columns/integer.py
@@ -35,6 +35,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -75,6 +76,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         if min is not None and min < self.min_value:
             raise ValueError("`min` is too small for the data type.")
@@ -97,6 +99,7 @@ class _BaseInteger(IsInMixin[int], OrdinalMixin[int], Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
 
     @classproperty

--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -41,6 +41,7 @@ class List(Column):
         min_length: int | None = None,
         max_length: int | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -77,6 +78,7 @@ class List(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=nullable,
@@ -85,6 +87,7 @@ class List(Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.inner = inner
         self.min_length = min_length

--- a/dataframely/columns/object.py
+++ b/dataframely/columns/object.py
@@ -25,6 +25,7 @@ class Object(Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -49,12 +50,14 @@ class Object(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=nullable,
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
 
     @property

--- a/dataframely/columns/string.py
+++ b/dataframely/columns/string.py
@@ -33,6 +33,7 @@ class String(Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -69,6 +70,7 @@ class String(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=nullable,
@@ -77,6 +79,7 @@ class String(Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.min_length = min_length
         self.max_length = max_length

--- a/dataframely/columns/struct.py
+++ b/dataframely/columns/struct.py
@@ -35,6 +35,7 @@ class Struct(Column):
         check: Check | None = None,
         alias: str | None = None,
         metadata: dict[str, Any] | None = None,
+        description: str | None = None,
     ):
         """
         Args:
@@ -70,6 +71,7 @@ class Struct(Column):
                 this option does _not_ allow to refer to the column with two different
                 names, the specified alias is the only valid name.
             metadata: A dictionary of metadata to attach to the column.
+            description: A human-readable description of the column.
         """
         super().__init__(
             nullable=nullable,
@@ -78,6 +80,7 @@ class Struct(Column):
             check=check,
             alias=alias,
             metadata=metadata,
+            description=description,
         )
         self.inner = inner
 

--- a/tests/columns/test_description.py
+++ b/tests/columns/test_description.py
@@ -1,0 +1,80 @@
+# Copyright (c) QuantCo 2024-2026
+# SPDX-License-Identifier: BSD-3-Clause
+
+from typing import Annotated, get_args, get_origin
+
+import pytest
+
+import dataframely as dy
+from dataframely._compat import pydantic
+from dataframely.columns import Column
+from dataframely.testing import ALL_COLUMN_TYPES
+
+pytestmark = pytest.mark.with_optionals
+
+
+class SchemaWithDescription(dy.Schema):
+    a = dy.Int64(description="The number of widgets.")
+    b = dy.String()
+
+
+def test_description_attribute() -> None:
+    assert SchemaWithDescription.a.description == "The number of widgets."
+    assert SchemaWithDescription.b.description is None
+
+
+def test_with_description() -> None:
+    col = dy.Int64()
+    assert col.description is None
+    updated = col.with_description("hello")
+    assert updated.description == "hello"
+    # Original is unchanged.
+    assert col.description is None
+
+
+@pytest.mark.parametrize("column_type", ALL_COLUMN_TYPES)
+def test_description_in_pydantic_field(column_type: type[Column]) -> None:
+    col = column_type(description="my description")
+    field = col.pydantic_field()
+    # Expect an Annotated[..., FieldInfo(description=...)]
+    assert get_origin(field) is Annotated or hasattr(field, "__metadata__")
+    metadata = get_args(field)[1:]
+    field_info = next((m for m in metadata if hasattr(m, "description")), None)
+    assert field_info is not None
+    assert field_info.description == "my description"
+
+
+def test_description_propagated_through_model() -> None:
+    col = dy.Int64(description="The number of widgets.")
+    model = pydantic.create_model("Test", val=col.pydantic_field())
+    schema = model.model_json_schema()
+    assert schema["properties"]["val"]["description"] == "The number of widgets."
+
+
+@pytest.mark.parametrize(
+    "col",
+    [
+        dy.Object(description="my description"),
+        dy.List(dy.Int64(), description="my description"),
+        dy.Array(dy.Int64(), shape=2, description="my description"),
+        dy.Struct({"x": dy.Int64()}, description="my description"),
+        dy.Enum(["a", "b"], description="my description"),
+    ],
+)
+def test_description_for_compound_columns(col: Column) -> None:
+    assert col.description == "my description"
+    field = col.pydantic_field()
+    metadata = getattr(field, "__metadata__", ())
+    field_info = next((m for m in metadata if hasattr(m, "description")), None)
+    assert field_info is not None
+    assert field_info.description == "my description"
+
+
+def test_no_description_no_field_info() -> None:
+    # When neither description nor any other constraint is set, the pydantic
+    # field should not embed a description.
+    col = dy.Bool()
+    field = col.pydantic_field()
+    metadata = getattr(field, "__metadata__", ())
+    for m in metadata:
+        assert getattr(m, "description", None) is None

--- a/tests/columns/test_description.py
+++ b/tests/columns/test_description.py
@@ -19,24 +19,32 @@ class SchemaWithDescription(dy.Schema):
 
 
 def test_description_attribute() -> None:
+    # Act / Assert
     assert SchemaWithDescription.a.description == "The number of widgets."
     assert SchemaWithDescription.b.description is None
 
 
 def test_with_description() -> None:
+    # Arrange
     col = dy.Int64()
-    assert col.description is None
+
+    # Act
     updated = col.with_description("hello")
-    assert updated.description == "hello"
-    # Original is unchanged.
+
+    # Assert
     assert col.description is None
+    assert updated.description == "hello"
 
 
 @pytest.mark.parametrize("column_type", ALL_COLUMN_TYPES)
 def test_description_in_pydantic_field(column_type: type[Column]) -> None:
+    # Arrange
     col = column_type(description="my description")
+
+    # Act
     field = col.pydantic_field()
-    # Expect an Annotated[..., FieldInfo(description=...)]
+
+    # Assert
     assert get_origin(field) is Annotated or hasattr(field, "__metadata__")
     metadata = get_args(field)[1:]
     field_info = next((m for m in metadata if hasattr(m, "description")), None)
@@ -45,9 +53,14 @@ def test_description_in_pydantic_field(column_type: type[Column]) -> None:
 
 
 def test_description_propagated_through_model() -> None:
+    # Arrange
     col = dy.Int64(description="The number of widgets.")
     model = pydantic.create_model("Test", val=col.pydantic_field())
+
+    # Act
     schema = model.model_json_schema()
+
+    # Assert
     assert schema["properties"]["val"]["description"] == "The number of widgets."
 
 
@@ -62,8 +75,11 @@ def test_description_propagated_through_model() -> None:
     ],
 )
 def test_description_for_compound_columns(col: Column) -> None:
-    assert col.description == "my description"
+    # Act
     field = col.pydantic_field()
+
+    # Assert
+    assert col.description == "my description"
     metadata = getattr(field, "__metadata__", ())
     field_info = next((m for m in metadata if hasattr(m, "description")), None)
     assert field_info is not None
@@ -71,10 +87,13 @@ def test_description_for_compound_columns(col: Column) -> None:
 
 
 def test_no_description_no_field_info() -> None:
-    # When neither description nor any other constraint is set, the pydantic
-    # field should not embed a description.
+    # Arrange
     col = dy.Bool()
+
+    # Act
     field = col.pydantic_field()
+
+    # Assert
     metadata = getattr(field, "__metadata__", ())
     for m in metadata:
         assert getattr(m, "description", None) is None

--- a/tests/columns/test_matches.py
+++ b/tests/columns/test_matches.py
@@ -19,6 +19,8 @@ import dataframely as dy
         (dy.Int32(), dy.Int32(), True),
         (dy.Int32(), dy.Int32(alias="foo"), True),
         (dy.Int32(alias="bar"), dy.Int32(alias="foo"), True),
+        (dy.Int32(), dy.Int32(description="foo"), True),
+        (dy.Int32(description="bar"), dy.Int32(description="foo"), True),
         (dy.String(regex="^a$"), dy.String(regex="^a$"), True),
         (dy.String(regex="^a$"), dy.String(regex="^b$"), False),
         (

--- a/tests/schema/test_serialization.py
+++ b/tests/schema/test_serialization.py
@@ -40,6 +40,14 @@ def test_simple_serialization() -> None:
         create_schema("test", {"a": dy.Int64(check=[lambda expr: expr > 5])}),
         create_schema("test", {"a": dy.Int64(check={"x": lambda expr: expr > 5})}),
         create_schema("test", {"a": dy.Int64(alias="foo")}),
+        create_schema("test", {"a": dy.Int64(description="a column description")}),
+        create_schema(
+            "test",
+            {
+                "a": dy.Int64(description="first"),
+                "b": dy.String(description="second"),
+            },
+        ),
         create_schema("test", {"a": dy.Enum(["a"])}),
         create_schema("test", {"a": dy.Decimal(scale=2, min=Decimal("1.5"))}),
         create_schema("test", {"a": dy.Date(min=dt.date(2020, 1, 1))}),

--- a/tests/schema/test_storage.py
+++ b/tests/schema/test_storage.py
@@ -41,15 +41,28 @@ TESTERS = [
     ["tmp_path", pytest.param("s3_tmp_path", marks=pytest.mark.s3)],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "schema",
+    [
+        create_schema("test", {"a": dy.Int64(), "b": dy.String()}),
+        create_schema(
+            "test",
+            {
+                "a": dy.Int64(description="first column"),
+                "b": dy.String(description="second column"),
+            },
+        ),
+    ],
+)
 def test_read_write_if_schema_matches(
     tester: SchemaStorageTester,
     any_tmp_path: str,
     mocker: pytest_mock.MockerFixture,
     validation: Validation,
     lazy: Literal[True] | Literal[False],
+    schema: type[dy.Schema],
 ) -> None:
     # Arrange
-    schema = create_schema("test", {"a": dy.Int64(), "b": dy.String()})
     df = schema.create_empty()
     tester.write_typed(schema, df, any_tmp_path, lazy=lazy)
 


### PR DESCRIPTION
# Motivation

Implements https://github.com/Quantco/dataframely/issues/323#issuecomment-4505728567 and closes #132.

## Why introduce a `description` parameter?

Unfortunately, attribute docstrings cannot be extracted at runtime ([PEP 224](https://peps.python.org/pep-0224/) was rejected). Hence, this is the only way to make use of the description at runtime, e.g. to pass to `pydantic` field descriptions.