### PR TITLE
ci: Fix `cargo-auditable` Linux release wheel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,12 @@ jobs:
         run: |
           printf '@cargo auditable %%*\n' > "C:/cargo-auditable-wrapper.cmd"
           echo "CARGO=C:\\cargo-auditable-wrapper.cmd" >> "$GITHUB_ENV"
+      - name: Prepare cargo-auditable wrapper (Linux)
+        # The wrapper itself is created inside the manylinux container by
+        # `before-script-linux` below; here we only point CARGO at it on the
+        # host so maturin-action forwards the value via `-e CARGO=...`.
+        if: github.event_name == 'release' && runner.os == 'Linux'
+        run: echo "CARGO=/usr/local/bin/cargo-auditable-wrapper" >> "$GITHUB_ENV"
       - name: Build wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0 # zizmor: ignore[cache-poisoning]
         with:


### PR DESCRIPTION
# Motivation

The v2.10.0 release wheel build failed on `linux-64` and `linux-aarch64` ([failed run](https://github.com/Quantco/dataframely/actions/runs/26503473342)) while the same SHA's `push`-triggered build on `main` succeeded. On `release` events, `docker-options` expands to `-e CARGO=\${{ env.CARGO }}`, but no host step was setting `CARGO` on Linux — so the value passed to the container was empty, which clobbered `CARGO` inside it and broke `cargo rustc`.

# Changes

Add a Linux-side `Prepare cargo-auditable wrapper` step that sets `CARGO=/usr/local/bin/cargo-auditable-wrapper` — the path of the wrapper that `before-script-linux` already creates inside the manylinux container.