### PR TITLE
perf: Use semi-join instead of `unique` for checking 1:N relationships

### DIFF
--- a/dataframely/functional.py
+++ b/dataframely/functional.py
@@ -84,9 +84,9 @@ def require_relationship_one_to_at_least_one(
         columns, filtered to ensure a 1:{1,N} relationship.
     """
     if drop_duplicates:
-        return lhs.unique(on, keep="none").join(rhs.unique(on), on=on)
+        return lhs.unique(on, keep="none").join(rhs, on=on, how="semi")
 
-    return lhs.join(rhs.unique(on), on=on)
+    return lhs.join(rhs, on=on, how="semi")
 
 
 # ------------------------------------------------------------------------------------ #

--- a/tests/benches/test_collection.py
+++ b/tests/benches/test_collection.py
@@ -15,13 +15,13 @@ def partitioned_dataset(dataset: pl.DataFrame) -> dict[str, pl.DataFrame]:
             "elevation",
             "aspect",
             "slope",
-            idx=pl.int_range(pl.len(), dtype=pl.UInt32),
+            idx=pl.int_range(pl.len(), dtype=pl.UInt32).shuffle(),
         ),
         "second": dataset.select(
             "horizontal_distance_to_hydrology",
             "vertical_distance_to_hydrology",
             "horizontal_distance_to_roadways",
-            idx=pl.int_range(pl.len(), dtype=pl.UInt32),
+            idx=pl.int_range(pl.len(), dtype=pl.UInt32).shuffle(),
         ),
     }
 


### PR DESCRIPTION
# Motivation

The current implementation builds two separate hash tables for no good reason. On some example data, this improves runtime of the filter itself by ~2.5x. End-to-end on the updated benchmark, it yields a ~5-10% runtime speedup.
