### PR TITLE
fix: Ignore failure propagation in collection member that is ignored in filters and reject failure propagation without common primary key

### DIFF
--- a/dataframely/collection/_base.py
+++ b/dataframely/collection/_base.py
@@ -144,7 +144,7 @@ class CollectionMeta(ABCMeta):
             if len(_common_primary_key(non_ignored_member_schemas)) == 0:
                 raise ImplementationError(
                     "Members of a collection must have an overlapping primary key "
-                    "but did not find any."
+                    "if they use filters or failure-propagation, but did not find any."
                 )
 
         # 2) Check that filter names do not overlap with any column or rule names

--- a/dataframely/collection/_base.py
+++ b/dataframely/collection/_base.py
@@ -377,7 +377,7 @@ class BaseCollection(metaclass=CollectionMeta):
         return {
             name
             for name, member in cls.members().items()
-            if member.propagate_row_failures
+            if member.propagate_row_failures and not member.ignored_in_filters
         }
 
     @classmethod

--- a/dataframely/collection/_base.py
+++ b/dataframely/collection/_base.py
@@ -133,8 +133,14 @@ class CollectionMeta(ABCMeta):
         ]
 
         # 1) Check that there are overlapping primary keys that allow the application
-        # of filters.
-        if len(non_ignored_member_schemas) > 0 and len(result.filters) > 0:
+        # of filters and the propagation of row failures.
+        has_failure_propagation = any(
+            member.propagate_row_failures and not member.ignored_in_filters
+            for member in result.members.values()
+        )
+        if len(non_ignored_member_schemas) > 0 and (
+            len(result.filters) > 0 or has_failure_propagation
+        ):
             if len(_common_primary_key(non_ignored_member_schemas)) == 0:
                 raise ImplementationError(
                     "Members of a collection must have an overlapping primary key "

--- a/tests/collection/test_implementation.py
+++ b/tests/collection/test_implementation.py
@@ -245,3 +245,28 @@ def test_collection_primary_key_but_not_common() -> None:
             },
             filters={"testfilter": Filter(lambda c: c.first.filter(pl.col("a") > 0))},
         )
+
+
+def test_collection_propagate_row_failures_no_common_primary_key() -> None:
+    """Propagating row failures requires a common primary key between members."""
+
+    class FirstSchema(dy.Schema):
+        a = dy.Integer(primary_key=True)
+
+    class SecondSchema(dy.Schema):
+        b = dy.Integer(primary_key=True)
+
+    with pytest.raises(
+        ImplementationError,
+        match=r"Members of a collection must have an overlapping primary key",
+    ):
+        create_collection_raw(
+            "test",
+            annotations={
+                "first": Annotated[
+                    dy.LazyFrame[FirstSchema],
+                    dy.CollectionMember(propagate_row_failures=True),
+                ],
+                "second": dy.LazyFrame[SecondSchema],
+            },
+        )

--- a/tests/collection/test_propagate_row_failures.py
+++ b/tests/collection/test_propagate_row_failures.py
@@ -78,8 +78,37 @@ def invalid_b() -> pl.LazyFrame:
     )
 
 
+class IgnoredPropagatingCollection(dy.Collection):
+    a: dy.LazyFrame[MyTestSchema]
+    b: Annotated[
+        dy.LazyFrame[MyTestSchema2],
+        dy.CollectionMember(ignored_in_filters=True, propagate_row_failures=True),
+    ]
+
+
 def test_collection_propagate_row_failures_meta() -> None:
     assert MyTestCollection._failure_propagating_members() == {"b"}
+
+
+def test_collection_propagate_row_failures_ignored_in_filters_meta() -> None:
+    # `ignored_in_filters` disables propagation, so `b` must not be listed.
+    assert IgnoredPropagatingCollection._failure_propagating_members() == set()
+
+
+def test_collection_propagate_row_failures_ignored_in_filters(
+    valid_a: pl.LazyFrame,
+    invalid_b: pl.LazyFrame,
+) -> None:
+    success, failures = IgnoredPropagatingCollection.filter(
+        {
+            "a": valid_a,
+            "b": invalid_b,
+        },
+        cast=True,
+    )
+    # An ignored member does not propagate its row failures, so `a` keeps all rows.
+    assert success.a.select("shared").collect().to_series().to_list() == [1, 2, 3]
+    assert "b|failure_propagation" not in failures["a"].counts()
 
 
 def test_collection_propagate_row_failure_no_propagation(

--- a/tests/collection/test_propagate_row_failures.py
+++ b/tests/collection/test_propagate_row_failures.py
@@ -99,14 +99,19 @@ def test_collection_propagate_row_failures_ignored_in_filters(
     valid_a: pl.LazyFrame,
     invalid_b: pl.LazyFrame,
 ) -> None:
+    # Arrange
+    dfs = {
+        "a": valid_a,
+        "b": invalid_b,
+    }
+
+    # Act
     success, failures = IgnoredPropagatingCollection.filter(
-        {
-            "a": valid_a,
-            "b": invalid_b,
-        },
+        dfs,
         cast=True,
     )
-    # An ignored member does not propagate its row failures, so `a` keeps all rows.
+
+    # Assert: An ignored member does not propagate its row failures, so `a` keeps all rows.
     assert success.a.select("shared").collect().to_series().to_list() == [1, 2, 3]
     assert "b|failure_propagation" not in failures["a"].counts()
 


### PR DESCRIPTION
# Motivation

Opposed to the docs, for a member that is ignored in filters, the failure propagation property is currently not ignored.  

Additionally, we should reject collections if they have a failure-propagating member (not ignored) but no common primary key. Like for filters, entries that are filtered out of a failure-propagating member would be propagated across members, which does not work without common primary key. 

# Changes

- Ignore failure propagation for members that are ignored in filters
- Extend the criteria for rejection
- Add tests