### PR TITLE
ci: Have dependabot keep `Cargo.lock` up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,16 @@ updates:
       prefix: ci
     cooldown:
       default-days: 7
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    versioning-strategy: lockfile-only
+    groups:
+      cargo:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: build
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Motivation

We want regular updates to our rust dependencies.

# Changes

* Added `cargo` config for `dependabot`