### PR TITLE
fix: Evaluate simple rules before joining group rule columns

### DIFF
--- a/dataframely/_rule.py
+++ b/dataframely/_rule.py
@@ -218,12 +218,15 @@ def with_evaluation_rules(lf: pl.LazyFrame, rules: dict[str, Rule]) -> pl.LazyFr
 
     # Before we can select all of the simple expressions, we need to turn the
     # group rules into something to use in a `select` statement as well.
+    # NOTE: The simple expressions are evaluated BEFORE the group rules are joined onto
+    #  the frame. Otherwise, rules using dynamic column selection (e.g.
+    #  `pl.col(pl.Boolean)`) would also select the boolean group rule columns.
     result = (
         # NOTE: A value of `null` always validates successfully as nullability should
         #  already be checked via dedicated rules.
-        lf.pipe(_with_group_rules, group_rules).with_columns(
+        lf.with_columns(
             **{name: expr.fill_null(True) for name, expr in simple_exprs.items()},
-        )
+        ).pipe(_with_group_rules, group_rules)
     )
 
     # If there is at least one rule that checks for successful dtype casting, we need

--- a/tests/core_validation/test_rule_evaluation.py
+++ b/tests/core_validation/test_rule_evaluation.py
@@ -106,3 +106,22 @@ def test_multiple_group_rules() -> None:
         }
     )
     assert_frame_equal(actual, expected)
+
+
+def test_dynamic_column_selection_with_group_rule() -> None:
+    # The group rule adds a boolean column to the frame. A simple rule that selects
+    # columns dynamically must not see it (see #332).
+    lf = pl.LazyFrame({"a": [1, 1, 2], "x": [False, False, True]})
+    rules: dict[str, Rule] = {
+        "no_bool_set": Rule(~pl.any_horizontal(pl.col(pl.Boolean))),
+        "unique_x": GroupRule(pl.col("x").n_unique() == 1, group_columns=["a"]),
+    }
+    actual = evaluate_rules(lf, rules)
+
+    expected = pl.LazyFrame(
+        {
+            "no_bool_set": [True, True, False],
+            "unique_x": [True, True, True],
+        }
+    )
+    assert_frame_equal(actual, expected, check_column_order=False)


### PR DESCRIPTION
Closes #332

# Motivation

A rule using dynamic column selection can fail unexpectedly as soon as the schema also has a group rule. In the reported MWE, `~pl.any_horizontal(pl.col(pl.Boolean))` validates fine on its own but fails once a `@dy.rule(group_by="x")` is added.

`with_evaluation_rules` joined the group rule evaluation columns onto the frame *first* and only then evaluated the simple rule expressions. Group rule columns are boolean, so the dynamic selector also picked up those internal columns.

# Changes

Simple expressions are now added before the group rules are joined, so they only ever see the user's own columns. Group rule evaluation is unaffected because those rules are computed from the original frame either way.

Adds `test_dynamic_column_selection_with_group_rule`, which fails on `main` and passes with this change.
