### PR TITLE
ci: Automatically bump Rust toolchain via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,15 @@ updates:
       prefix: build
     cooldown:
       default-days: 7
+  - package-ecosystem: rust-toolchain
+    directory: /
+    schedule:
+      interval: quarterly
+    cooldown:
+      default-days: 7
+    groups:
+      rust-toolchain:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
# Motivation

Our toolchain is already old and causes issues with the VScode `rust-analyzer` extension.
