### PR TITLE
feat: Implement Arrow PyCapsule interface for schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,11 +135,12 @@ dependencies = [
 
 [[package]]
 name = "atoi_simd"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad17c7c205c2c28b527b9845eeb91cf1b4d008b438f98ce0e628227a822758e"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
 dependencies = [
  "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -200,16 +201,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -299,7 +300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -312,7 +313,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -350,6 +351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,15 +377,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -449,12 +447,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -485,12 +482,22 @@ checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+]
+
+[[package]]
+name = "digest-io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -634,12 +641,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.13.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -737,16 +744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,11 +763,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -858,9 +853,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "rayon",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -868,6 +860,14 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "rayon",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -934,6 +934,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1007,7 +1016,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1399,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "half",
  "libc",
@@ -1517,7 +1526,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1569,11 +1578,10 @@ dependencies = [
 [[package]]
 name = "polars"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f1f122456ec136102033b13f71905b7c3f01e526642679c86aace9f9cdefde"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "getrandom 0.2.17",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "polars-arrow",
  "polars-buffer",
  "polars-compute",
@@ -1592,8 +1600,7 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d4892d5cc6461bb4a184d18e6fa03a5d316ee1d6de06a33dfa08d479fbc2db"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "atoi_simd",
  "bitflags",
@@ -1605,9 +1612,9 @@ dependencies = [
  "either",
  "ethnum",
  "getrandom 0.2.17",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "lz4",
  "num-traits",
@@ -1637,8 +1644,7 @@ dependencies = [
 [[package]]
 name = "polars-async"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e87f836190486f500b28347436985cc0af29b7a514e53f98840d396ce4d5f5"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "atomic-waker",
  "crossbeam-channel",
@@ -1649,7 +1655,7 @@ dependencies = [
  "polars-config",
  "polars-error",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.1",
  "slotmap",
  "tokio",
 ]
@@ -1657,8 +1663,7 @@ dependencies = [
 [[package]]
 name = "polars-buffer"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481eeaf33c544ac0dd71a2e375553ca2fdae47b3472a96eaccb6eb43218783d"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "bytemuck",
  "either",
@@ -1670,8 +1675,7 @@ dependencies = [
 [[package]]
 name = "polars-compute"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55d41642a9ee887ac394c5a310af3256fa8340a86cde2cb624c515aa963461c"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -1679,14 +1683,14 @@ dependencies = [
  "either",
  "fast-float2",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "num-traits",
  "polars-arrow",
  "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.1",
  "serde",
  "strength_reduce",
  "strum_macros",
@@ -1697,8 +1701,7 @@ dependencies = [
 [[package]]
 name = "polars-config"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65af861341b00eac73bcb65423fb5cc3d2322526d6b7561a0ddf094947c38033"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "polars-error",
  "serde",
@@ -1707,8 +1710,7 @@ dependencies = [
 [[package]]
 name = "polars-core"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5924fc46306054bae78f9d35ea5e404cf185baa7f170eb55a16ff95191069c"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "bitflags",
  "boxcar",
@@ -1716,8 +1718,8 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "either",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
+ "getrandom 0.4.2",
+ "hashbrown 0.17.1",
  "indexmap",
  "itoa",
  "num-traits",
@@ -1731,7 +1733,7 @@ dependencies = [
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.1",
  "rand_distr",
  "rayon",
  "regex",
@@ -1747,11 +1749,10 @@ dependencies = [
 [[package]]
 name = "polars-dtype"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b65a750bb99ea66be90c8a7e336f6f3a87427a0f7f89d2a40adae98314e9b27"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "boxcar",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "polars-arrow",
  "polars-error",
  "polars-utils",
@@ -1762,8 +1763,7 @@ dependencies = [
 [[package]]
 name = "polars-error"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49a75e3406b9b5b4e5ff177877fe0de766e9688fbdb263a7b25f293dc47d61a"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "object_store",
  "parking_lot",
@@ -1777,11 +1777,10 @@ dependencies = [
 [[package]]
 name = "polars-expr"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21fdd37e8d9ef109f13d3454baffa0a57041cf60069123b8a2bd846c8ad0205"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "bitflags",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-traits",
  "polars-arrow",
  "polars-buffer",
@@ -1793,7 +1792,7 @@ dependencies = [
  "polars-row",
  "polars-time",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.1",
  "rayon",
  "recursive",
  "regex",
@@ -1803,8 +1802,7 @@ dependencies = [
 [[package]]
 name = "polars-ffi"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fddc8eb96794c42758233f017cfe1cedb3ab24296583171a94d6f452f0ef1f6"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -1813,20 +1811,20 @@ dependencies = [
 [[package]]
 name = "polars-io"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6363a1c44a65fe8d73cce7fe4d77c9b6fea3a0da44007012e755e5b4e65aa078"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "async-trait",
  "atoi_simd",
  "blake3",
  "bytes",
  "chrono",
+ "crossbeam-queue",
  "fast-float2",
  "fastrand",
  "fs4",
  "futures",
  "glob",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "home",
  "itoa",
  "memchr",
@@ -1846,7 +1844,7 @@ dependencies = [
  "polars-schema",
  "polars-time",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.1",
  "rayon",
  "regex",
  "reqwest",
@@ -1860,12 +1858,11 @@ dependencies = [
 [[package]]
 name = "polars-json"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dca6cd170370ef7e189a4c362846c57553843653c3fe65aafe12ca77599987c"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "chrono",
  "fallible-streaming-iterator",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itoa",
  "num-traits",
@@ -1881,8 +1878,7 @@ dependencies = [
 [[package]]
 name = "polars-lazy"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809d9590232a37d638337629c18279af97bdb0d17c3d8b2b6bb186e903e8bd5e"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "bitflags",
  "chrono",
@@ -1908,8 +1904,7 @@ dependencies = [
 [[package]]
 name = "polars-mem-engine"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c6b7d162c506bc8eee82b065fa0399ebcd20b8f08675a534f3d360904ba38"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "memmap2",
  "polars-arrow",
@@ -1928,8 +1923,7 @@ dependencies = [
 [[package]]
 name = "polars-ooc"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3eea0b386837b760a97ec9c92df99cbc10f94885cae060fd7100f9b794163"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "async-trait",
  "boxcar",
@@ -1937,17 +1931,20 @@ dependencies = [
  "polars-async",
  "polars-config",
  "polars-core",
+ "polars-error",
  "polars-io",
  "polars-utils",
+ "rand 0.10.1",
+ "rand_distr",
  "thread_local",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
 name = "polars-ops"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb146490a717ac5ae4ff3a22a5adf3ebae79361f187b1f550f9e24783d7ad765"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "argminmax",
  "base64",
@@ -1955,7 +1952,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "hex",
  "indexmap",
  "libm",
@@ -1981,15 +1978,14 @@ dependencies = [
 [[package]]
 name = "polars-parquet"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b79ba2103c00cbb9c5dd4459ffff1d8ce15286c7a6d376a04c711df20d8b7"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "async-stream",
  "base64",
  "bytemuck",
  "ethnum",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-traits",
  "polars-arrow",
  "polars-buffer",
@@ -2017,8 +2013,7 @@ dependencies = [
 [[package]]
 name = "polars-plan"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5ccc230515adb10762a8c7b0df03fd88f3328deb5b60e9b1eeb2eceef4d344"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "bitflags",
  "blake3",
@@ -2026,9 +2021,11 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "digest-io",
  "either",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "hex",
  "indexmap",
  "memmap2",
  "num-traits",
@@ -2059,8 +2056,7 @@ dependencies = [
 [[package]]
 name = "polars-row"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4e3254450024078e10c919ecd3b467bdcfdd5cf386c2ca6eedec89bd4771d2"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -2075,8 +2071,7 @@ dependencies = [
 [[package]]
 name = "polars-schema"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8a0de8951d02576fd0cdcecd9c605a6b6364d3105b7469b8d7874ea34eea2f"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "indexmap",
  "polars-error",
@@ -2088,8 +2083,7 @@ dependencies = [
 [[package]]
 name = "polars-sql"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b282a6164927eb12774b66b071b773a1573173ae53758e8d4df50389ff06efa2"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "bitflags",
  "hex",
@@ -2108,13 +2102,13 @@ dependencies = [
 [[package]]
 name = "polars-stream"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa8ff4ee21799898579595a0ef2fb728d0a9cac3d061835fb7f7f6dd854734a"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "async-channel",
  "async-trait",
  "bitflags",
  "bytes",
+ "chrono",
  "chrono-tz",
  "crossbeam-channel",
  "crossbeam-queue",
@@ -2150,8 +2144,7 @@ dependencies = [
 [[package]]
 name = "polars-time"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1063fe074c4212a54917be604377c6e6bfbc8b6c942a5c57be214e4ccaaafdf"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -2174,8 +2167,7 @@ dependencies = [
 [[package]]
 name = "polars-utils"
 version = "0.54.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590b0a94aa8f97992d52f1198600ecc1c1f7cfa03c1b31cae057143455804ac0"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "argminmax",
  "bincode",
@@ -2187,7 +2179,7 @@ dependencies = [
  "foldhash 0.2.0",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "libc",
  "memmap2",
@@ -2197,7 +2189,7 @@ dependencies = [
  "polars-config",
  "polars-error",
  "pyo3",
- "rand 0.9.5",
+ "rand 0.10.1",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -2286,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -2300,18 +2292,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2319,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2331,13 +2323,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -2345,8 +2336,7 @@ dependencies = [
 [[package]]
 name = "pyo3-polars"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad2fcbcb8a0dc41549b73e6481c8fbe236a5461d8cf6d639e840b04d594990a"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "libc",
  "once_cell",
@@ -2367,8 +2357,7 @@ dependencies = [
 [[package]]
 name = "pyo3-polars-derive"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b357518a15e1b8d8c5b33cefb9f5893365946e757d391b62d255dd60916b47c"
+source = "git+https://github.com/borchero/polars?rev=80c5e6b4d828e7c1fb1eb357bc8647697938e885#80c5e6b4d828e7c1fb1eb357bc8647697938e885"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2514,12 +2503,12 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.5",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2975,12 +2964,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -3078,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.60.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505aa16b045c4c1375bf5f125cce3813d0176325bfe9ffc4a903f423de7774ff"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",
@@ -3089,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028e551d5e270b31b9f3ea271778d9d827148d4287a5d96167b6bb9787f5cc38"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3146,9 +3135,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3206,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -3745,37 +3734,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3786,19 +3761,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -3826,33 +3801,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -3861,16 +3821,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -3879,7 +3830,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3887,15 +3838,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3915,7 +3857,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3940,7 +3882,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -3953,11 +3895,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,20 @@ polars = { version = ">=0.50", default-features = false, features = [
 polars-arrow = ">=0.50"
 polars-core = ">=0.50"
 pyo3 = { version = ">=0.25", features = ["abi3-py310", "extension-module"] }
-pyo3-polars = { version = ">=0.23.1", features = ["derive"] }
+pyo3-polars = { version = ">=0.23.1", features = ["derive", "dtype-full"] }
 rand = { version = "0.9", features = ["std_rng"] }
 rayon = "*"
 regex = "*"
 regex-syntax = "0.8"
 serde = "*"
 thiserror = "2.0"
+
+# FIXME: Temporarily override polars with fork until https://github.com/pola-rs/polars/pull/28598 is released
+[patch.crates-io]
+polars = { git = "https://github.com/borchero/polars", rev = "80c5e6b4d828e7c1fb1eb357bc8647697938e885" }
+polars-arrow = { git = "https://github.com/borchero/polars", rev = "80c5e6b4d828e7c1fb1eb357bc8647697938e885" }
+polars-core = { git = "https://github.com/borchero/polars", rev = "80c5e6b4d828e7c1fb1eb357bc8647697938e885" }
+pyo3-polars = { git = "https://github.com/borchero/polars", rev = "80c5e6b4d828e7c1fb1eb357bc8647697938e885" }
 
 [dev-dependencies]
 rstest = "*"

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
+from ._native import arrow_c_schema
 from ._rule import DtypeCastRule, GroupRule, Rule, RuleFactory
 from .columns import Column
 from .exc import ImplementationError
@@ -267,6 +268,12 @@ class SchemaMeta(ABCMeta):
                     )
                 result.rules[attr] = value
         return result
+
+    def __arrow_c_schema__(cls) -> object:
+        columns: dict[str, Column] = cls.columns()  # type: ignore[attr-defined]
+        return arrow_c_schema(
+            [(name, col.dtype, col.nullable) for name, col in columns.items()]
+        )
 
     def __repr__(cls) -> str:
         parts = [f'[Schema "{cls.__name__}"]']

--- a/dataframely/_base_schema.py
+++ b/dataframely/_base_schema.py
@@ -272,7 +272,10 @@ class SchemaMeta(ABCMeta):
     def __arrow_c_schema__(cls) -> object:
         columns: dict[str, Column] = cls.columns()  # type: ignore[attr-defined]
         return arrow_c_schema(
-            [(name, col.dtype, col.nullable) for name, col in columns.items()]
+            [
+                (name, col.dtype, col._arrow_nullability())
+                for name, col in columns.items()
+            ]
         )
 
     def __repr__(cls) -> str:

--- a/dataframely/_native.pyi
+++ b/dataframely/_native.pyi
@@ -1,6 +1,16 @@
-from typing import overload
+from typing import Any, overload
 
 import polars as pl
+
+def arrow_c_schema(columns: list[tuple[str, pl.DataType, bool]]) -> Any:
+    """Build an Arrow C schema PyCapsule from a schema's columns.
+
+    Args:
+        columns: The columns of the schema as `(name, dtype, nullable)` tuples.
+
+    Returns:
+        A PyCapsule implementing the Arrow PyCapsule interface for schemas.
+    """
 
 def format_rule_failures(
     failures: list[tuple[str, int]],

--- a/dataframely/_native.pyi
+++ b/dataframely/_native.pyi
@@ -2,11 +2,16 @@ from typing import Any, overload
 
 import polars as pl
 
-def arrow_c_schema(columns: list[tuple[str, pl.DataType, bool]]) -> Any:
+# The nullability of a column, combined with the nullability of its nested fields (if any).
+Nullability = tuple[bool, list["Nullability"]]
+
+def arrow_c_schema(
+    columns: list[tuple[str, pl.DataType, Nullability]],
+) -> Any:
     """Build an Arrow C schema PyCapsule from a schema's columns.
 
     Args:
-        columns: The columns of the schema as `(name, dtype, nullable)` tuples.
+        columns: The columns of the schema as `(name, dtype, nullability)` tuples.
 
     Returns:
         A PyCapsule implementing the Arrow PyCapsule interface for schemas.

--- a/dataframely/columns/_base.py
+++ b/dataframely/columns/_base.py
@@ -118,6 +118,10 @@ class Column(ABC):
         """
         return self.dtype == dtype
 
+    def _arrow_nullability(self) -> tuple[bool, list[Any]]:
+        """The nullability of this column and its nested fields for Arrow export."""
+        return (self.nullable, [])
+
     # ---------------------------------- VALIDATION ---------------------------------- #
 
     def validation_rules(self, expr: pl.Expr) -> dict[str, pl.Expr]:

--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -124,7 +124,13 @@ class Array(Column):
                 )
 
     def _arrow_nullability(self) -> tuple[bool, list[Any]]:
-        return (self.nullable, [self.inner._arrow_nullability()])
+        # Multi-dimensional arrays are nested fixed-size lists in Arrow, one level per
+        # dimension. Only the innermost field carries the inner column's nullability; the
+        # intermediate dimensions are always nullable (matching polars).
+        nullability = self.inner._arrow_nullability()
+        for _ in range(len(self.shape) - 1):
+            nullability = (True, [nullability])
+        return (self.nullable, [nullability])
 
     def _pyarrow_field_of_shape(self, shape: Sequence[int]) -> pa.Field:
         if shape:

--- a/dataframely/columns/array.py
+++ b/dataframely/columns/array.py
@@ -123,6 +123,9 @@ class Array(Column):
                     f"SQL column cannot have 'Array' type for dialect '{dialect}'."
                 )
 
+    def _arrow_nullability(self) -> tuple[bool, list[Any]]:
+        return (self.nullable, [self.inner._arrow_nullability()])
+
     def _pyarrow_field_of_shape(self, shape: Sequence[int]) -> pa.Field:
         if shape:
             size, *rest = shape

--- a/dataframely/columns/list.py
+++ b/dataframely/columns/list.py
@@ -144,6 +144,9 @@ class List(Column):
                     f"SQL column cannot have 'List' type for dialect '{dialect}'."
                 )
 
+    def _arrow_nullability(self) -> tuple[bool, list[Any]]:
+        return (self.nullable, [self.inner._arrow_nullability()])
+
     @property
     def pyarrow_dtype(self) -> pa.DataType:
         # NOTE: Polars uses `large_list`s by default.

--- a/dataframely/columns/struct.py
+++ b/dataframely/columns/struct.py
@@ -125,6 +125,12 @@ class Struct(Column):
             case _:
                 raise NotImplementedError("SQL column cannot have 'Struct' type.")
 
+    def _arrow_nullability(self) -> tuple[bool, list[Any]]:
+        return (
+            self.nullable,
+            [col._arrow_nullability() for col in self.inner.values()],
+        )
+
     @property
     def pyarrow_dtype(self) -> pa.DataType:
         return pa.struct([col.pyarrow_field(name) for name, col in self.inner.items()])

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -242,11 +242,13 @@ df_concat = HouseSchema.cast(pl.concat([df1, df2]))
 Lastly, `dataframely` schemas can be used to integrate with external tools:
 
 - `HouseSchema.create_empty()` creates an empty `dy.DataFrame[HouseSchema]` that can be used for testing
+- `HouseSchema` implements the [Arrow PyCapsule interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrowschema-export),
+  allowing to easily translate the dataframely schema into other packages' schema definitions:
+  - `polars.Schema(HouseSchema)` can be used to construct a polars schema
+  - `pyarrow.schema(HouseSchema)` can be used to construct a [pyarrow](https://arrow.apache.org/docs/python/index.html) schema
 - `HouseSchema.to_sqlalchemy_columns()` provides a list of [sqlalchemy](https://www.sqlalchemy.org) columns that can be
   used to
   create SQL tables using types and constraints in line with the schema
-- `HouseSchema.to_pyarrow_schema()` provides a [pyarrow](https://arrow.apache.org/docs/python/index.html) schema with
-  appropriate column dtypes and nullability information
 - You can use `dy.DataFrame[HouseSchema]` (or the `LazyFrame` equivalent) as fields in
   [pydantic](https://pydantic.dev) models, including support for validation and serialization. Integration with
   pydantic is unstable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,8 @@ schema information to data frame type hints.
 - Introspect validation failure information for run-time failures
 - Enhanced type hints for validated data frames allowing users to clearly express expectations about inputs and
   outputs (i.e., contracts) in data pipelines
-- Integrate schemas with external tools (e.g., `sqlalchemy` or `pyarrow`)
+- Integrate schemas with external tools (e.g., `sqlalchemy`, `pyarrow`, or via the
+  [Arrow PyCapsule](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrowschema-export))
 - Generate test data that comply with a schema or collection of schemas and its validation rules
 
 ```{toctree}

--- a/src/arrow.rs
+++ b/src/arrow.rs
@@ -1,0 +1,33 @@
+use polars::prelude::*;
+use polars_arrow::datatypes::{ArrowDataType, Field as ArrowField};
+use polars_arrow::ffi::{export_field_to_c, ArrowSchema};
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+use pyo3_polars::PyDataType;
+
+/// Build an Arrow C schema PyCapsule from a schema's columns.
+#[pyfunction]
+pub fn arrow_c_schema<'py>(
+    py: Python<'py>,
+    columns: Vec<(String, PyDataType, bool)>,
+) -> PyResult<Bound<'py, PyCapsule>> {
+    // Construct the Arrow fields
+    let fields = columns
+        .into_iter()
+        .map(|(name, dtype, nullable)| {
+            // Use `to_arrow_field` (rather than `to_arrow`) so that field metadata, e.g.
+            // for categorical columns, is preserved. We need to manually overwrite nullability
+            // here as polars defaults to all fields being nullable.
+            let field = dtype.0.to_arrow_field(name.into(), CompatLevel::newest());
+            ArrowField {
+                is_nullable: nullable,
+                ..field
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Wrap the fields into a PyCapsule
+    let schema_field = ArrowField::new(PlSmallStr::EMPTY, ArrowDataType::Struct(fields), false);
+    let c_schema: ArrowSchema = export_field_to_c(&schema_field);
+    PyCapsule::new_with_value(py, c_schema, c"arrow_schema")
+}

--- a/src/arrow.rs
+++ b/src/arrow.rs
@@ -5,24 +5,27 @@ use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 use pyo3_polars::PyDataType;
 
+/// The nullability of a (possibly nested) column: its own nullability along with the
+/// nullability of any child fields.
+#[derive(FromPyObject)]
+pub struct Nullability(bool, Vec<Nullability>);
+
 /// Build an Arrow C schema PyCapsule from a schema's columns.
 #[pyfunction]
 pub fn arrow_c_schema<'py>(
     py: Python<'py>,
-    columns: Vec<(String, PyDataType, bool)>,
+    columns: Vec<(String, PyDataType, Nullability)>,
 ) -> PyResult<Bound<'py, PyCapsule>> {
     // Construct the Arrow fields
     let fields = columns
         .into_iter()
-        .map(|(name, dtype, nullable)| {
+        .map(|(name, dtype, nullability)| {
             // Use `to_arrow_field` (rather than `to_arrow`) so that field metadata, e.g.
-            // for categorical columns, is preserved. We need to manually overwrite nullability
-            // here as polars defaults to all fields being nullable.
+            // for categorical columns, is preserved. Also, we need to manually overwrite the
+            // nullability here (recursively, for nested fields) as polars defaults to all
+            // fields being nullable.
             let field = dtype.0.to_arrow_field(name.into(), CompatLevel::newest());
-            ArrowField {
-                is_nullable: nullable,
-                ..field
-            }
+            apply_nullability(field, &nullability)
         })
         .collect::<Vec<_>>();
 
@@ -30,4 +33,29 @@ pub fn arrow_c_schema<'py>(
     let schema_field = ArrowField::new(PlSmallStr::EMPTY, ArrowDataType::Struct(fields), false);
     let c_schema: ArrowSchema = export_field_to_c(&schema_field);
     PyCapsule::new_with_value(py, c_schema, c"arrow_schema")
+}
+
+fn apply_nullability(field: ArrowField, nullability: &Nullability) -> ArrowField {
+    let dtype = match field.dtype {
+        ArrowDataType::LargeList(inner) => {
+            ArrowDataType::LargeList(Box::new(apply_nullability(*inner, &nullability.1[0])))
+        }
+        ArrowDataType::FixedSizeList(inner, width) => ArrowDataType::FixedSizeList(
+            Box::new(apply_nullability(*inner, &nullability.1[0])),
+            width,
+        ),
+        ArrowDataType::Struct(fields) => ArrowDataType::Struct(
+            fields
+                .into_iter()
+                .zip(&nullability.1)
+                .map(|(field, nullability)| apply_nullability(field, nullability))
+                .collect(),
+        ),
+        other => other,
+    };
+    ArrowField {
+        is_nullable: nullability.0,
+        dtype,
+        ..field
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod arrow;
 pub mod polars_plugin;
 mod regex;
 use pyo3::prelude::*;
@@ -11,5 +12,6 @@ fn native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(regex::regex_matching_string_length, m)?)?;
     m.add_function(wrap_pyfunction!(regex::regex_sample, m)?)?;
     m.add_function(wrap_pyfunction!(polars_plugin::format_rule_failures, m)?)?;
+    m.add_function(wrap_pyfunction!(arrow::arrow_c_schema, m)?)?;
     Ok(())
 }

--- a/tests/columns/test_arrow_c_schema.py
+++ b/tests/columns/test_arrow_c_schema.py
@@ -1,0 +1,76 @@
+# Copyright (c) QuantCo 2025-2026
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import dataframely as dy
+from dataframely.columns import Column
+from dataframely.testing import (
+    COLUMN_TYPES,
+    SUPERTYPE_COLUMN_TYPES,
+    create_schema,
+)
+
+pa = pytest.importorskip("pyarrow")
+
+pytestmark = pytest.mark.with_optionals
+
+
+@pytest.mark.parametrize(
+    "column", [dy.Categorical(nullable=True), dy.Enum(["a", "b"], nullable=True)]
+)
+def test_field_metadata_preserved(column: dy.Column) -> None:
+    # Arrange
+    schema = create_schema("test", {"a": column})
+
+    # Act
+    field = pa.schema(schema).field("a")
+
+    # Assert
+    expected_field = pa.table(schema.create_empty()).schema.field("a")
+    assert field.metadata is not None
+    assert field.metadata == expected_field.metadata
+
+
+def test_multiple_columns() -> None:
+    # Arrange
+    schema = create_schema(
+        "test", {"a": dy.Int32(nullable=False), "b": dy.Integer(nullable=True)}
+    )
+
+    # Act
+    result = str(pa.schema(schema)).split("\n")
+
+    # Assert
+    assert result == [
+        "a: int32 not null",
+        "b: int64",
+    ]
+
+
+@pytest.mark.parametrize("column_type", COLUMN_TYPES + SUPERTYPE_COLUMN_TYPES)
+@pytest.mark.parametrize("nullable", [True, False])
+def test_nullability_information(column_type: type[Column], nullable: bool) -> None:
+    # Arrange
+    schema = create_schema("test", {"a": column_type(nullable=nullable)})
+
+    # Act
+    result = pa.schema(schema)
+
+    # Assert
+    assert ("not null" in str(result)) != nullable
+
+
+@pytest.mark.parametrize(
+    "column",
+    [dy.List(dy.Int64(), nullable=True), dy.Struct({"a": dy.Int64()}, nullable=True)],
+)
+def test_nested_nullability_information(column: dy.Column) -> None:
+    # Arrange
+    schema = create_schema("test", {"a": column})
+
+    # Act
+    result = pa.schema(schema)
+
+    # Assert
+    assert "not null" in str(result)

--- a/tests/columns/test_arrow_pycapsule.py
+++ b/tests/columns/test_arrow_pycapsule.py
@@ -1,19 +1,17 @@
 # Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
+import pyarrow as pa
 import pytest
 
 import dataframely as dy
 from dataframely.columns import Column
 from dataframely.testing import (
     COLUMN_TYPES,
+    NO_VALIDATION_COLUMN_TYPES,
     SUPERTYPE_COLUMN_TYPES,
     create_schema,
 )
-
-pa = pytest.importorskip("pyarrow")
-
-pytestmark = pytest.mark.with_optionals
 
 
 @pytest.mark.parametrize(
@@ -61,20 +59,157 @@ def test_nullability_information(column_type: type[Column], nullable: bool) -> N
     assert ("not null" in str(result)) != nullable
 
 
-@pytest.mark.parametrize(
-    "column",
-    [
-        dy.List(dy.Int64(), nullable=True),
-        dy.Array(dy.Int64(), shape=2, nullable=True),
-        dy.Struct({"a": dy.Int64()}, nullable=True),
-    ],
-)
-def test_nested_nullability_information(column: dy.Column) -> None:
+@pytest.mark.parametrize("column_type", COLUMN_TYPES)
+@pytest.mark.parametrize("inner_nullable", [True, False])
+def test_inner_nullability_struct(
+    column_type: type[Column], inner_nullable: bool
+) -> None:
     # Arrange
-    schema = create_schema("test", {"a": column})
+    inner = column_type(nullable=inner_nullable)
+    schema = create_schema("test", {"a": dy.Struct({"a": inner})})
 
     # Act
-    result = pa.schema(schema)
+    pa_schema = pa.schema(schema)
 
     # Assert
-    assert "not null" in str(result)
+    struct_field = pa_schema.field("a")
+    inner_field = struct_field.type[0]
+    assert inner_field.nullable == inner_nullable
+
+
+@pytest.mark.parametrize("column_type", COLUMN_TYPES)
+@pytest.mark.parametrize("inner_nullable", [True, False])
+def test_inner_nullability_list(
+    column_type: type[Column], inner_nullable: bool
+) -> None:
+    # Arrange
+    inner = column_type(nullable=inner_nullable)
+    schema = create_schema("test", {"a": dy.List(inner)})
+
+    # Act
+    pa_schema = pa.schema(schema)
+
+    # Assert
+    list_field = pa_schema.field("a")
+    inner_field = list_field.type.value_field
+    assert inner_field.nullable == inner_nullable
+
+
+@pytest.mark.parametrize(
+    "column_type", [c for c in NO_VALIDATION_COLUMN_TYPES if c is not dy.Any]
+)
+@pytest.mark.parametrize("inner_nullable", [True, False])
+def test_inner_nullability_array(
+    column_type: type[Column], inner_nullable: bool
+) -> None:
+    # Arrange
+    inner = column_type(nullable=inner_nullable)
+    schema = create_schema("test", {"a": dy.Array(inner, 1)})
+
+    # Act
+    pa_schema = pa.schema(schema)
+
+    # Assert
+    array_field = pa_schema.field("a")
+    inner_field = array_field.type.value_field
+    assert inner_field.nullable == inner_nullable
+
+
+@pytest.mark.parametrize("inner_nullable", [True, False])
+def test_multidimensional_array_nullability(inner_nullable: bool) -> None:
+    # Arrange
+    # Multi-dimensional arrays become nested fixed-size lists in Arrow. Only the
+    # innermost field carries the inner column's nullability; intermediate dimensions
+    # are always nullable.
+    inner = dy.Int64(nullable=inner_nullable)
+    schema = create_schema("test", {"a": dy.Array(inner, (2, 3))})
+
+    # Act
+    pa_schema = pa.schema(schema)
+
+    # Assert
+    intermediate_field = pa_schema.field("a").type.value_field
+    innermost_field = intermediate_field.type.value_field
+    assert intermediate_field.nullable
+    assert innermost_field.nullable == inner_nullable
+
+
+def test_nested_struct_in_list_preserves_nullability() -> None:
+    """Test that nested struct fields in lists preserve nullability."""
+    # Arrange
+    schema = create_schema(
+        "test",
+        {
+            "a": dy.List(
+                dy.Struct(
+                    {
+                        "required": dy.String(nullable=False),
+                        "optional": dy.String(nullable=True),
+                    },
+                    nullable=True,
+                ),
+                nullable=True,
+            )
+        },
+    )
+
+    # Act
+    pa_schema = pa.schema(schema)
+
+    # Assert
+    list_field = pa_schema.field("a")
+    struct_type = list_field.type.value_field.type
+    assert not struct_type[0].nullable
+    assert struct_type[1].nullable
+
+
+def test_nested_list_in_struct_preserves_nullability() -> None:
+    """Test that nested list fields in structs preserve nullability."""
+    # Arrange
+    schema = create_schema(
+        "test",
+        {
+            "a": dy.Struct(
+                {"list_field": dy.List(dy.String(nullable=False), nullable=True)},
+                nullable=True,
+            )
+        },
+    )
+
+    # Act
+    pa_schema = pa.schema(schema)
+
+    # Assert
+    struct_field = pa_schema.field("a")
+    list_type = struct_field.type[0].type
+    assert not list_type.value_field.nullable
+
+
+def test_deeply_nested_nullability() -> None:
+    # Arrange
+    schema = create_schema(
+        "test",
+        {
+            "a": dy.Struct(
+                {
+                    "nested": dy.Struct(
+                        {
+                            "required": dy.String(nullable=False),
+                            "optional": dy.String(nullable=True),
+                        },
+                        nullable=True,
+                    ),
+                },
+                nullable=True,
+            )
+        },
+    )
+
+    # Act
+    pa_schema = pa.schema(schema)
+
+    # Assert
+    outer_struct = pa_schema.field("a").type
+    inner_struct = outer_struct[0].type
+    assert not inner_struct[0].nullable  # required field
+    assert inner_struct[1].nullable  # optional field

--- a/tests/columns/test_arrow_pycapsule.py
+++ b/tests/columns/test_arrow_pycapsule.py
@@ -1,7 +1,6 @@
 # Copyright (c) QuantCo 2025-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
-import pyarrow as pa
 import pytest
 
 import dataframely as dy
@@ -12,6 +11,10 @@ from dataframely.testing import (
     SUPERTYPE_COLUMN_TYPES,
     create_schema,
 )
+
+pa = pytest.importorskip("pyarrow")
+
+pytestmark = pytest.mark.with_optionals
 
 
 @pytest.mark.parametrize(

--- a/tests/columns/test_arrow_pycapsule.py
+++ b/tests/columns/test_arrow_pycapsule.py
@@ -63,7 +63,11 @@ def test_nullability_information(column_type: type[Column], nullable: bool) -> N
 
 @pytest.mark.parametrize(
     "column",
-    [dy.List(dy.Int64(), nullable=True), dy.Struct({"a": dy.Int64()}, nullable=True)],
+    [
+        dy.List(dy.Int64(), nullable=True),
+        dy.Array(dy.Int64(), shape=2, nullable=True),
+        dy.Struct({"a": dy.Int64()}, nullable=True),
+    ],
 )
 def test_nested_nullability_information(column: dy.Column) -> None:
     # Arrange


### PR DESCRIPTION
# Motivation

Currently, we implement `to_polars_schema`, `to_pyarrow_schema`, and there could be a need to implement this conversion for more packages going forward (e.g. for https://github.com/borchero/ducklake-sdk).

In order not to be required to implement the conversion manually, _for every other package_, we can leverage the [Arrow PyCapsule Interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html) to obtain a "canonical" representation of the schema in Arrow. This schema can then be imported by other packages supporting the interface. Today, this includes, e.g., `polars`, `pyarrow`, and `ducklake-sdk`.

# Changes

- Implement `__arrow_c_schema__` on `dy.Schema`. The implementation is done in our custom Rust code as we need to "correct" nullability information which would be lost by calling `__arrow_c_schema__` on a `pl.Schema`. Building the PyCapsule in Python would be possible but very annoying with `ctypes`.
