### PR TITLE
ci: Unset `sccache` to relieve cache usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,6 @@ jobs:
           command: build
           args: --out dist --release -i python3.10
           manylinux: auto
-          sccache: ${{ github.event_name != 'release' }}
           # NOTE: We also need to set up cargo-auditable inside the docker container
           # where the linux build is performed.
           docker-options: ${{ case(github.event_name == 'release', format('-e CARGO={0}', env.CARGO), '') }}


### PR DESCRIPTION
# Motivation

We currently have thousands of caches, most of which are `sccache`.
