### PR TITLE
docs: Use column description in skill schema example

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -25,10 +25,8 @@ class MyHouseSchema(dy.Schema):
 
     street = dy.String(primary_key=True)
     number = dy.UInt16(primary_key=True)
-    #: Description on the number of rooms.
-    rooms = dy.UInt8()
-    #: Description on the area of the house.
-    area = dy.UInt16()
+    rooms = dy.UInt8(description="Number of rooms")
+    area = dy.UInt16(description="Area of the house")
 ```
 
 The schema can be used in type hints via `dy.DataFrame[MyHouseSchema]` and `dy.LazyFrame[MyHouseSchema]` to express
@@ -41,8 +39,9 @@ runtime.
 
 ### Defining Constraints
 
-Persist all implicit assumptions on the data as constraints in the schema. Use docstrings purely to answer the "what"
-about the column contents.
+Persist all implicit assumptions on the data as constraints in the schema. Prefer using the `description` argument to
+answer the "what" about the column contents, while comments can be used to specify details that are not strictly
+schema-related or relevant only to a specific data interface.
 
 - Use the most specific type possible for each column (e.g. `dy.Enum` instead of `dy.String` when applicable).
 - Use pre-defined arguments (e.g. `nullable`, `min`, `regex`) for column-level constraints if possible.


### PR DESCRIPTION
# Motivation

Having comment lines (`#: `) before column definitions in the `SKILL.md` code examples leads coding agents to produce verbose dataframe schemas that prepend comments above every column definition.

# Changes

- Updated `MyHouseSchema` in `skills/SKILL.md` to use the native `description="..."` parameter on column definitions (`description="Number of rooms"`, `description="Area of the house"`) instead of preceding `#: ` comments.
- Refined the schema constraint guidelines to prefer the `description` argument for column contents while allowing comments for context not strictly schema-related or interface-specific.